### PR TITLE
Add error messages to output flags when no file name is given

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- `cargo-concordium` now checks that the user input from the output flags consists of a path and a file name.
 - Add support for V3 schemas that include support for event schemas. This enables
   `cargo-concordium` to build and interact with smart contracts using
   `concordium-std` version 4.1. `Cargo-concordium` now always generates V3 schemas.

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -177,11 +177,11 @@ pub fn build_contract(
 
     let out_filename = match out {
         Some(out) => {
-            // A path name and a filename needs to be provided when using the `--out` flag.
-            if out.file_name().is_none() {
+            // A path and a filename need to be provided when using the `--out` flag.
+            if out.file_name().is_none() || out.is_dir() {
                 anyhow::bail!(
-                    "The `--out` flag requires a path and a filename e.g. \
-                     `./my/path/my_smart_contract.wasm.v1`"
+                    "The `--out` flag requires a path and a filename (expected input: \
+                     `./my/path/my_smart_contract.wasm.v1`)"
                 );
             }
             out

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -385,6 +385,15 @@ pub fn main() -> anyhow::Result<()> {
                 );
 
                 if let Some(schema_out) = schema_out {
+                    // A path name and a filename needs to be provided when using the `--schema-out`
+                    // flag.
+                    if schema_out.file_name().is_none() {
+                        anyhow::bail!(
+                            "The `--schema-out` flag requires a path and a filename e.g. \
+                             `./my/path/schema.bin`"
+                        );
+                    }
+
                     eprintln!("   Writing schema to {}.", schema_out.display());
                     fs::write(schema_out, &module_schema_bytes)
                         .context("Could not write schema file.")?;

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -385,12 +385,12 @@ pub fn main() -> anyhow::Result<()> {
                 );
 
                 if let Some(schema_out) = schema_out {
-                    // A path name and a filename needs to be provided when using the `--schema-out`
+                    // A path and a filename need to be provided when using the `--schema-out`
                     // flag.
-                    if schema_out.file_name().is_none() {
+                    if schema_out.file_name().is_none() || schema_out.is_dir() {
                         anyhow::bail!(
-                            "The `--schema-out` flag requires a path and a filename e.g. \
-                             `./my/path/schema.bin`"
+                            "The `--schema-out` flag requires a path and a filename (expected \
+                             input: `./my/path/schema.bin`)"
                         );
                     }
 


### PR DESCRIPTION
## Purpose

closes #13

## Changes

Add better error messages to provide users more information on how the `--out` and `--schema-out` flags expect a `path + file name` as input.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
