### PR TITLE
Add conversion of schema into base64

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.7.0
+
+- Add `schema-base64` command to convert a given schema to base64 format.
+- Add `--schema-base64-out` option to `cargo concordium build` to optionally
+  output the schema in base64 format.
+
 ## 2.6.0
 
 - Add `schema-json` command to get schemas for individual entrypoints from the
@@ -10,7 +16,7 @@
 ## 2.5.0
 
 - Add support for sampling random numbers for randomized testing with `cargo concordium test`.
-- Add support for providing a seed to initialize a random generator to 
+- Add support for providing a seed to initialize a random generator to
   `cargo-concordium`. The generator can be used for randomized testing.
   Command format: `cargo concordium test --seed 1234567890`. The provided seed value
   is a `u64` number. If the seed is not provided, a random one will be sampled.

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -212,7 +212,7 @@ checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cargo-concordium"
-version = "2.6.0"
+version = "2.7.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-concordium"
-version = "2.6.0"
+version = "2.7.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license-file = "../LICENSE"

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -389,7 +389,7 @@ pub fn init_concordium_project(path: impl AsRef<Path>) -> anyhow::Result<()> {
 
 /// Write the provided JSON value to the file inside the `root` directory.
 /// The file is named after contract_name, except if contract_name contains
-/// unsuitable chracters. Then the counter is used to name the file.
+/// unsuitable characters. Then the counter is used to name the file.
 fn write_schema_json(
     root: &Path,
     contract_name: &str,
@@ -424,7 +424,11 @@ fn write_schema_json(
 
 /// Write the provided schema in its base64 representation to a file inside the
 /// `root` directory as well as print the base64 representation to the console.
-pub fn write_schema_base64(root: &Path, schema: &VersionedModuleSchema) -> anyhow::Result<()> {
+pub fn write_schema_base64(
+    root: &Path,
+    schema: &VersionedModuleSchema,
+    base64_log: bool,
+) -> anyhow::Result<()> {
     let mut out_path = root.to_path_buf();
 
     let manifest = Manifest::from_path("Cargo.toml").context("Could not read Cargo.toml.")?;
@@ -437,10 +441,12 @@ pub fn write_schema_base64(root: &Path, schema: &VersionedModuleSchema) -> anyho
 
     let schema_base64 = ENCODER.encode(to_bytes(schema));
 
-    println!(
-        "    The base64 conversion of the schema is:\n{}",
-        schema_base64
-    );
+    if base64_log {
+        println!(
+            "    The base64 conversion of the schema is:\n{}",
+            schema_base64
+        );
+    }
 
     println!("    Writing base64 schema to {}.", out_path.display());
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -422,38 +422,29 @@ fn write_schema_json(
     Ok(())
 }
 
-/// Write the provided schema in its base64 representation to a file inside the
-/// `root` directory if `Some(root)` is given.
-/// Print the provided schema in its base64 representation to the console if
-/// `schema_base64_log` is true.
+/// Write the provided schema in its base64 representation to a file or print it
+/// to the console if `out` is None.
 pub fn write_schema_base64(
     out: Option<PathBuf>,
     schema: &VersionedModuleSchema,
 ) -> anyhow::Result<()> {
     let schema_base64 = ENCODER.encode(to_bytes(schema));
 
-    // printing base64 schema to console
-    if out.is_none() {
-        println!(
-            "   The base64 conversion of the schema is:\n{}",
-            schema_base64
-        );
-    }
+    match out {
+        // writing base64 schema to file
+        Some(out) => {
+            println!("   Writing base64 schema to {}.", out.display());
 
-    // writing base64 schema to file
-    if let Some(out) = out {
-        // A path and a filename need to be provided when using the `--out` flag.
-        if out.file_name().is_none() || out.is_dir() {
-            anyhow::bail!(
-                "The `--out` flag requires a path and a filename (expected input: \
-                 `./my/path/schema_base64.b64` or `-`)"
-            );
+            // save the schema base64 representation to the file
+            std::fs::write(out, schema_base64).context("Unable to write schema output.")?;
         }
-
-        println!("   Writing base64 schema to {}.", out.display());
-
-        // save the schema base64 representation into the file
-        std::fs::write(out, schema_base64).context("Unable to write schema output.")?;
+        // printing base64 schema to console
+        None => {
+            println!(
+                "   The base64 conversion of the schema is:\n{}",
+                schema_base64
+            )
+        }
     }
 
     Ok(())

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -146,9 +146,10 @@ enum Command {
             long = "out",
             short = "o",
             default_value = "-",
-            help = "Write the converted base64 representation of the schema to a file at the \
-                    specified location or print it to the console when the default value `-` is \
-                    used. Directory path must exist. (expected input: `./my/path/` or `-`)."
+            help = "Path and filename to a file to write the converted base64 representation to \
+                    or use the default value `-` to print the base64 schema to the console. \
+                    Directory path must exist. (expected input: `./my/path/base64_schema.b64` or \
+                    `-`)."
         )]
         out:          PathBuf,
         #[structopt(
@@ -213,7 +214,8 @@ enum Command {
             long = "schema-base64-out",
             short = "b",
             help = "Builds the contract schema and writes it in base64 format to the specified \
-                    directory."
+                    directory/filename or prints the base64 schema to the console if the value \
+                    `-` is used (expected input: `./my/path/base64_schema.b64` or `-`)."
         )]
         schema_base64_out: Option<PathBuf>,
         #[structopt(
@@ -475,9 +477,7 @@ pub fn main() -> anyhow::Result<()> {
             let schema = get_schema(module_path, schema_path, wasm_version)
                 .context("Could not get schema.")?;
 
-            let mut path = PathBuf::new();
-            path.push("-");
-            if out == path {
+            if out == PathBuf::from("-") {
                 write_schema_base64(None, &schema).context("Could not log base64 schema.")?;
             } else {
                 // A valid path needs to be provided when using the `--out` flag.
@@ -570,9 +570,7 @@ pub fn main() -> anyhow::Result<()> {
                         .context("Could not write JSON schema files.")?;
                 }
                 if let Some(schema_base64_out) = schema_base64_out {
-                    let mut path = PathBuf::new();
-                    path.push("-");
-                    if schema_base64_out == path {
+                    if schema_base64_out == PathBuf::from("-") {
                         write_schema_base64(None, module_schema)
                             .context("Could not log base64 schema.")?;
                     } else {

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -146,10 +146,10 @@ enum Command {
             long = "out",
             short = "o",
             default_value = "-",
-            help = "Path and filename to a file to write the converted base64 representation to \
-                    or use the default value `-` to print the base64 schema to the console. \
-                    Directory path must exist. (expected input: `./my/path/base64_schema.b64` or \
-                    `-`)."
+            help = "Path and filename to write the converted base64 representation to or use the \
+                    default value `-` to print the base64 schema to the console. The path has to \
+                    exist while the file will be created. (expected input: \
+                    `./my/path/base64_schema.b64` or `-`)."
         )]
         out:          PathBuf,
         #[structopt(
@@ -213,9 +213,10 @@ enum Command {
             name = "schema-base64-out",
             long = "schema-base64-out",
             short = "b",
-            help = "Builds the contract schema and writes it in base64 format to the specified \
-                    directory/filename or prints the base64 schema to the console if the value \
-                    `-` is used (expected input: `./my/path/base64_schema.b64` or `-`)."
+            help = "Builds the contract schema and writes it in base64 format to file at \
+                    specified location or prints the base64 schema to the console if the value \
+                    `-` is used. The path has to exist while the file will be created. (expected \
+                    input: `./my/path/base64_schema.b64` or `-`)."
         )]
         schema_base64_out: Option<PathBuf>,
         #[structopt(
@@ -477,8 +478,8 @@ pub fn main() -> anyhow::Result<()> {
             let schema = get_schema(module_path, schema_path, wasm_version)
                 .context("Could not get schema.")?;
 
-            if out == PathBuf::from("-") {
-                write_schema_base64(None, &schema).context("Could not log base64 schema.")?;
+            if out.as_path() == Path::new("-") {
+                write_schema_base64(None, &schema).context("Could not print base64 schema.")?;
             } else {
                 // A valid path needs to be provided when using the `--out` flag.
                 if out.file_name().is_none() || out.is_dir() {
@@ -570,9 +571,9 @@ pub fn main() -> anyhow::Result<()> {
                         .context("Could not write JSON schema files.")?;
                 }
                 if let Some(schema_base64_out) = schema_base64_out {
-                    if schema_base64_out == PathBuf::from("-") {
+                    if schema_base64_out.as_path() == Path::new("-") {
                         write_schema_base64(None, module_schema)
-                            .context("Could not log base64 schema.")?;
+                            .context("Could not print base64 schema.")?;
                     } else {
                         if schema_base64_out.file_name().is_none() || schema_base64_out.is_dir() {
                             anyhow::bail!(

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -132,7 +132,53 @@ enum Command {
         )]
         module_path:  Option<PathBuf>,
     },
-
+    #[structopt(
+        name = "schema-base64",
+        about = "Convert a schema into its base64 representation and output it to a file.
+        A schema has to be provided either as part of a smart contract module or with the schema \
+                 flag. You need to use exactly one of the two flags(`--schema` or `--module`) \
+                 with this command."
+    )]
+    SchemaBase64 {
+        #[structopt(
+            name = "out",
+            long = "out",
+            short = "o",
+            default_value = ".",
+            help = "Writes the converted bsae64 representation of the schema to a file at the \
+                    specified location. Directory path must exist. (expected input: `./my/path/`)."
+        )]
+        out:          PathBuf,
+        #[structopt(
+            name = "schema",
+            long = "schema",
+            short = "s",
+            conflicts_with = "module",
+            required_unless = "module",
+            help = "Path and filename to a file with a schema (expected input: \
+                    `./my/path/schema.bin`)."
+        )]
+        schema_path:  Option<PathBuf>,
+        #[structopt(
+            name = "wasm-version",
+            long = "wasm-version",
+            short = "v",
+            help = "If the supplied schema or module is the unversioned one this flag should be \
+                    used to supply the version explicitly. Unversioned schemas and modules were \
+                    produced by older versions of `concordium-std` and `cargo-concordium`."
+        )]
+        wasm_version: Option<WasmVersion>,
+        #[structopt(
+            name = "module",
+            long = "module",
+            short = "m",
+            conflicts_with = "schema",
+            required_unless = "schema",
+            help = "Path and filename to a file with a smart contract module (expected input: \
+                    `./my/path/module.wasm.v1`)."
+        )]
+        module_path:  Option<PathBuf>,
+    },
     #[structopt(
         name = "build",
         about = "Build a deployment ready smart-contract module."
@@ -144,14 +190,14 @@ enum Command {
             short = "e",
             help = "Builds the contract schema and embeds it into the wasm module."
         )]
-        schema_embed:    bool,
+        schema_embed:      bool,
         #[structopt(
             name = "schema-out",
             long = "schema-out",
             short = "s",
             help = "Builds the contract schema and writes it to file at specified location."
         )]
-        schema_out:      Option<PathBuf>,
+        schema_out:        Option<PathBuf>,
         #[structopt(
             name = "schema-json-out",
             long = "schema-json-out",
@@ -159,14 +205,22 @@ enum Command {
             help = "Builds the contract schema and writes it in JSON format to the specified \
                     directory."
         )]
-        schema_json_out: Option<PathBuf>,
+        schema_json_out:   Option<PathBuf>,
+        #[structopt(
+            name = "schema-base64-out",
+            long = "schema-base64-out",
+            short = "b",
+            help = "Builds the contract schema and writes it in base64 format to the specified \
+                    directory."
+        )]
+        schema_base64_out: Option<PathBuf>,
         #[structopt(
             name = "out",
             long = "out",
             short = "o",
             help = "Writes the resulting module to file at specified location."
         )]
-        out:             Option<PathBuf>,
+        out:               Option<PathBuf>,
         #[structopt(
             name = "contract-version",
             long = "contract-version",
@@ -174,12 +228,12 @@ enum Command {
             help = "Build a module of the given version.",
             default_value = "V1"
         )]
-        version:         utils::WasmVersion,
+        version:           utils::WasmVersion,
         #[structopt(
             raw = true,
             help = "Extra arguments passed to `cargo build` when building Wasm module."
         )]
-        cargo_args:      Vec<String>,
+        cargo_args:        Vec<String>,
     },
 }
 
@@ -405,67 +459,44 @@ pub fn main() -> anyhow::Result<()> {
                  `./my/path/`)."
             );
 
-            let schema = if let Some(module_path) = module_path {
-                let bytes = fs::read(module_path).context("Could not read module file.")?;
+            let schema = get_schema(module_path, schema_path, wasm_version)
+                .context("Could not get schema.")?;
 
-                let mut cursor = std::io::Cursor::new(&bytes[..]);
-                let (wasm_version, module) = match wasm_version {
-                    Some(v) => (v, &bytes[..]),
-                    None => {
-                        let wasm_version = utils::WasmVersion::read(&mut cursor).context(
-                            "Could not read module version from the supplied module file. Supply \
-                             the version using `--wasm-version`.",
-                        )?;
-                        (wasm_version, &cursor.into_inner()[8..])
-                    }
-                };
+            write_json_schema(&out, &schema).context("Could not write json schema files.")?
+        }
+        Command::SchemaBase64 {
+            out,
+            module_path,
+            schema_path,
+            wasm_version,
+        } => {
+            // A valid path needs to be provided when using the `--out` flag.
+            ensure!(
+                out.is_dir(),
+                "The `--out` value must point to an existing directory (expected input: \
+                 `./my/path/`)."
+            );
 
-                match wasm_version {
-                    utils::WasmVersion::V0 => utils::get_embedded_schema_v0(module).context(
-                        "Failed to get schema embedded in the module.\nPlease provide a smart \
-                         contract module with an embedded schema.",
-                    )?,
-                    utils::WasmVersion::V1 => {
-                        // get the module schema if available.
-                        utils::get_embedded_schema_v1(module).context(
-                            "Failed to get schema embedded in the module.\nPlease provide a smart \
-                             contract module with an embedded schema.",
-                        )?
-                    }
-                }
-            } else if let Some(schema_path) = schema_path {
-                let bytes = fs::read(schema_path).context("Could not read schema file.")?;
+            let schema = get_schema(module_path, schema_path, wasm_version)
+                .context("Could not get schema.")?;
 
-                if bytes.starts_with(VERSIONED_SCHEMA_MAGIC_HASH) {
-                    from_bytes::<VersionedModuleSchema>(&bytes)?
-                } else if let Some(wv) = wasm_version {
-                    match wv {
-                        WasmVersion::V0 => from_bytes(&bytes).map(VersionedModuleSchema::V0)?,
-                        WasmVersion::V1 => from_bytes(&bytes).map(VersionedModuleSchema::V1)?,
-                    }
-                } else {
-                    bail!(
-                        "Legacy unversioned schema was supplied, but no version was provided. Use \
-                         `--wasm-version` to specify the version."
-                    );
-                }
-            } else {
-                bail!("Exactly one of `--schema` or `--module` must be provided.");
-            };
-
-            write_json_schema(&out, &schema).context("Unable to output schemas.")?
+            write_schema_base64(&out, &schema).context("Could not write base64 schema file.")?
         }
         Command::Build {
             schema_embed,
             schema_out,
             schema_json_out,
+            schema_base64_out,
             out,
             version,
             cargo_args,
         } => {
             let build_schema = if schema_embed {
                 SchemaBuildOptions::BuildAndEmbed
-            } else if schema_out.is_some() || schema_json_out.is_some() {
+            } else if schema_out.is_some()
+                || schema_json_out.is_some()
+                || schema_base64_out.is_some()
+            {
                 SchemaBuildOptions::JustBuild
             } else {
                 SchemaBuildOptions::DoNotBuild
@@ -526,7 +557,16 @@ pub fn main() -> anyhow::Result<()> {
                          (expected input `./my/path/`)."
                     );
                     write_json_schema(&schema_json_out, module_schema)
-                        .context("Could not write schema file.")?;
+                        .context("Could not write json schema files.")?;
+                }
+                if let Some(schema_base64_out) = schema_base64_out {
+                    ensure!(
+                        schema_base64_out.is_dir(),
+                        "The `--schema-base64-out` flag should point to an existing directory \
+                         (expected input `./my/path/`)."
+                    );
+                    write_schema_base64(&schema_base64_out, module_schema)
+                        .context("Could not write base64 schema file.")?;
                 }
                 if schema_embed {
                     eprintln!("   Embedding schema into module.\n");
@@ -1530,6 +1570,58 @@ fn get_parameter(
     } else {
         Ok(Vec::new())
     }
+}
+
+fn get_schema(
+    module_path: Option<PathBuf>,
+    schema_path: Option<PathBuf>,
+    wasm_version: Option<WasmVersion>,
+) -> anyhow::Result<VersionedModuleSchema> {
+    let schema = if let Some(module_path) = module_path {
+        let bytes = fs::read(module_path).context("Could not read module file.")?;
+
+        let mut cursor = std::io::Cursor::new(&bytes[..]);
+        let (wasm_version, module) = match wasm_version {
+            Some(v) => (v, &bytes[..]),
+            None => {
+                let wasm_version = utils::WasmVersion::read(&mut cursor).context(
+                    "Could not read module version from the supplied module file. Supply the \
+                     version using `--wasm-version`.",
+                )?;
+                (wasm_version, &cursor.into_inner()[8..])
+            }
+        };
+
+        match wasm_version {
+            utils::WasmVersion::V0 => utils::get_embedded_schema_v0(module).context(
+                "Failed to get schema embedded in the module.\nPlease provide a smart contract \
+                 module with an embedded schema.",
+            )?,
+            utils::WasmVersion::V1 => utils::get_embedded_schema_v1(module).context(
+                "Failed to get schema embedded in the module.\nPlease provide a smart contract \
+                 module with an embedded schema.",
+            )?,
+        }
+    } else if let Some(schema_path) = schema_path {
+        let bytes = fs::read(schema_path).context("Could not read schema file.")?;
+
+        if bytes.starts_with(VERSIONED_SCHEMA_MAGIC_HASH) {
+            from_bytes::<VersionedModuleSchema>(&bytes)?
+        } else if let Some(wv) = wasm_version {
+            match wv {
+                WasmVersion::V0 => from_bytes(&bytes).map(VersionedModuleSchema::V0)?,
+                WasmVersion::V1 => from_bytes(&bytes).map(VersionedModuleSchema::V1)?,
+            }
+        } else {
+            bail!(
+                "Legacy unversioned schema was supplied, but no version was provided. Use \
+                 `--wasm-version` to specify the version."
+            );
+        }
+    } else {
+        bail!("Exactly one of `--schema` or `--module` must be provided.");
+    };
+    Ok(schema)
 }
 
 fn write_json_schema(out: &Path, schema: &VersionedModuleSchema) -> anyhow::Result<()> {


### PR DESCRIPTION
## Purpose

closes #27 

- Add `schema-base64` command to convert a given schema to base64 format.
- Add `--schema-base64-out` option to `cargo concordium build` to optionally output the schema in base64 format.
-  Provding the value `-`  to the  `--schema-base64-out` flag will log the bsae64 string to the console instead of writing it into a file.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
