### PR TITLE
Misc changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         build-dir:
           - 'cargo-concordium'
+          - 'concordium-smart-contract-testing'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -53,6 +54,7 @@ jobs:
       matrix:
         build-dir:
           - 'cargo-concordium'
+          - 'concordium-smart-contract-testing'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -78,6 +80,11 @@ jobs:
     needs:
       - lint_clippy
       - lint_fmt
+    strategy:
+      matrix:
+        build-dir:
+          - 'cargo-concordium'
+          - 'concordium-smart-contract-testing'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -92,7 +99,7 @@ jobs:
           target: ${{ env.TARGET }}
           components: clippy
       - name: Cargo check
-        working-directory: cargo-concordium
+        working-directory: ${{ matrix.build-dir }}
         run: cargo check --benches --tests
 
   "cargo_test":
@@ -104,6 +111,7 @@ jobs:
       matrix:
         build-dir:
           - 'cargo-concordium'
+          - 'concordium-smart-contract-testing'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -118,6 +126,3 @@ jobs:
       - name: Test
         working-directory: ${{ matrix.build-dir }}
         run: cargo test
-
-
-

--- a/concordium-smart-contract-testing/Cargo.toml
+++ b/concordium-smart-contract-testing/Cargo.toml
@@ -7,9 +7,9 @@ rust-version = "1.65"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-concordium_base = {path = "../concordium-base/rust-src/concordium_base"}
-concordium-smart-contract-engine = {path = "../concordium-base/smart-contracts/wasm-chain-integration"}
-concordium-wasm = {path = "../concordium-base/smart-contracts/wasm-transform"}
+concordium_base = {version = "1.0", path = "../concordium-base/rust-src/concordium_base"}
+concordium-smart-contract-engine = {version = "1.0", path = "../concordium-base/smart-contracts/wasm-chain-integration"}
+concordium-wasm = {version = "1.0", path = "../concordium-base/smart-contracts/wasm-transform"}
 sha2 = "0.10"
 anyhow = "1"
 thiserror = "1.0"

--- a/concordium-smart-contract-testing/Cargo.toml
+++ b/concordium-smart-contract-testing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "concordium-smart-contract-testing"
 version = "1.0.0"
 edition = "2021"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/concordium-smart-contract-testing/src/impls.rs
+++ b/concordium-smart-contract-testing/src/impls.rs
@@ -853,8 +853,8 @@ impl Chain {
     ///     Some(Amount::from_ccd(123))
     /// );
     /// ```
-    pub fn create_account(&mut self, address: AccountAddress, account: Account) -> Option<Account> {
-        self.accounts.insert(address.into(), account)
+    pub fn create_account(&mut self, account: Account) -> Option<Account> {
+        self.accounts.insert(account.address.into(), account)
     }
 
     /// Create a contract address by giving it the next available index.
@@ -1020,16 +1020,24 @@ impl Chain {
 
 impl Account {
     /// Create new [`Self`] with the provided account policy.
-    pub fn new_with_policy(balance: AccountBalance, policy: OwnedPolicy) -> Self {
-        Self { balance, policy }
+    pub fn new_with_policy(
+        address: AccountAddress,
+        balance: AccountBalance,
+        policy: OwnedPolicy,
+    ) -> Self {
+        Self {
+            balance,
+            policy,
+            address,
+        }
     }
 
     /// Create new [`Self`] with the provided balance and a default account
     /// policy.
     ///
     /// See [`new`][Self::new] for what the default policy is.
-    pub fn new_with_balance(balance: AccountBalance) -> Self {
-        Self::new_with_policy(balance, Self::empty_policy())
+    pub fn new_with_balance(address: AccountAddress, balance: AccountBalance) -> Self {
+        Self::new_with_policy(address, balance, Self::empty_policy())
     }
 
     /// Create new [`Self`] with the provided total balance.
@@ -1042,8 +1050,9 @@ impl Account {
     ///
     /// The [`AccountBalance`] will be created with the provided
     /// `total_balance`.
-    pub fn new(total_balance: Amount) -> Self {
+    pub fn new(address: AccountAddress, total_balance: Amount) -> Self {
         Self::new_with_policy(
+            address,
             AccountBalance {
                 total:  total_balance,
                 staked: Amount::zero(),
@@ -1308,8 +1317,8 @@ mod tests {
         let expected_amount = Amount::from_ccd(10);
         let expected_amount_other = Amount::from_ccd(123);
 
-        chain.create_account(acc, Account::new(expected_amount));
-        chain.create_account(acc_other, Account::new(expected_amount_other));
+        chain.create_account(Account::new(acc, expected_amount));
+        chain.create_account(Account::new(acc_other, expected_amount_other));
 
         assert_eq!(acc_eq, acc_alias_eq);
         assert_ne!(acc_eq, acc_other_eq);

--- a/concordium-smart-contract-testing/src/impls.rs
+++ b/concordium-smart-contract-testing/src/impls.rs
@@ -662,8 +662,11 @@ impl Chain {
     ///
     /// **Parameters:**
     ///  - `invoker`: the account paying for the transaction.
-    ///  - `sender`: the sender of the transaction, can also be a contract.
-    ///    TODO: This does not make sense. Senders cannot be contracts.
+    ///  - `sender`: the sender of the message, can be an account or contract.
+    ///    For top-level invocations, such as those caused by sending a contract
+    ///    update transaction on the chain, the `sender` is always the
+    ///    `invoker`. Here we provide extra freedom for testing invocations
+    ///    where the sender differs.
     ///  - `contract_address`: the contract to update.
     ///  - `entrypoint`: the entrypoint to call.
     ///  - `parameter`: the contract parameter.
@@ -673,15 +676,15 @@ impl Chain {
         &mut self,
         signer: Signer,
         invoker: AccountAddress,
-        sender: Address, // TODO: Why does this exist? contra
+        sender: Address,
         energy_reserved: Energy,
         payload: UpdateContractPayload,
     ) -> Result<ContractInvokeSuccess, ContractInvokeError> {
         // Ensure the sender exists.
         if !self.address_exists(sender) {
-            // TODO: Should we charge the header cost if the invoker exists but the sender
-            // doesn't?
-            // No, this situation should not happen.
+            // This situation never happens on the chain since to send a message the sender
+            // is verifier upfront. So what we do here is custom behaviour, and we reject
+            // without consuming any eneryg.
             return Err(ContractInvokeError {
                 energy_used:     Energy::from(0),
                 transaction_fee: Amount::zero(),

--- a/concordium-smart-contract-testing/src/impls.rs
+++ b/concordium-smart-contract-testing/src/impls.rs
@@ -45,7 +45,7 @@ impl ChainParameters {
 
     /// Create a new [`ChainParameters`](Self) with a specified `block_time`
     /// where
-    ///  - `micro_ccd_per_euro` defaults to `147235241 / 1`
+    ///  - `micro_ccd_per_euro` defaults to `50000 / 1`
     ///  - `euro_per_energy` defaults to `1 / 50000`.
     pub fn new_with_time(block_time: SlotTime) -> Self {
         Self {
@@ -106,7 +106,7 @@ impl Chain {
     }
 
     /// Create a new [`Chain`](Self) with a specified `block_time` where
-    ///  - `micro_ccd_per_euro` defaults to `147235241 / 1`
+    ///  - `micro_ccd_per_euro` defaults to `50000 / 1`
     ///  - `euro_per_energy` defaults to `1 / 50000`.
     pub fn new_with_time(block_time: SlotTime) -> Self {
         Self {
@@ -687,8 +687,8 @@ impl Chain {
         // Ensure the sender exists.
         if !self.address_exists(sender) {
             // This situation never happens on the chain since to send a message the sender
-            // is verifier upfront. So what we do here is custom behaviour, and we reject
-            // without consuming any eneryg.
+            // is verified upfront. So what we do here is custom behaviour, and we reject
+            // without consuming any energy.
             return Err(ContractInvokeError {
                 energy_used:     Energy::from(0),
                 transaction_fee: Amount::zero(),
@@ -738,9 +738,6 @@ impl Chain {
             });
         }
 
-        // Charge account for the reserved energy up front. This is to ensure that
-        // contract queries for the invoker balance are correct.
-        // The `amount` is handled in contract_invocation_worker.
         let contract_address = payload.address;
         let res = self.contract_invocation_worker(
             invoker,
@@ -781,7 +778,7 @@ impl Chain {
             Ok(s) => s.transaction_fee,
             Err(e) => e.transaction_fee,
         };
-        // Change for execution.
+        // Charge for execution.
         self.account_mut(invoker)
             .expect("existence already checked")
             .balance

--- a/concordium-smart-contract-testing/src/invocation/impls.rs
+++ b/concordium-smart-contract-testing/src/invocation/impls.rs
@@ -5,7 +5,7 @@ use crate::{
         contract_events_from_logs, from_interpreter_energy, lookup_module_cost,
         to_interpreter_energy,
     },
-    types::{Account, BalanceError, Chain, Contract, ContractModule, TransferError},
+    types::{Account, BalanceError, Contract, ContractModule, TransferError},
     AccountAddressEq,
 };
 use concordium_base::{

--- a/concordium-smart-contract-testing/src/invocation/impls.rs
+++ b/concordium-smart-contract-testing/src/invocation/impls.rs
@@ -27,44 +27,6 @@ use concordium_smart_contract_engine::{
 use concordium_wasm::artifact;
 use std::collections::{btree_map, BTreeMap};
 
-/// Invoke an entrypoint and get the result, [`ChangeSet`], and chain
-/// events.
-///
-/// **Preconditions:**
-///  - `invoker` exists
-///  - `invoker` has sufficient balance to pay for `remaining_energy`
-///  - `sender` exists
-///  - if the contract (`contract_address`) exists, then its `module` must also
-///    exist.
-pub(crate) fn invoke_entrypoint_and_get_changes<'a, 'b>(
-    chain: &'b Chain,
-    invoker: AccountAddress,
-    reserved_amount: Amount,
-    sender: Address,
-    remaining_energy: &'a mut Energy,
-    payload: UpdateContractPayload,
-) -> Result<
-    (
-        InvokeEntrypointResponse,
-        ChangeSet,
-        Vec<ContractTraceElement>,
-    ),
-    TestConfigurationError,
-> {
-    let mut contract_invocation = EntrypointInvocationHandler {
-        changeset: ChangeSet::new(),
-        remaining_energy,
-        chain,
-        reserved_amount,
-        invoker,
-    };
-
-    let mut trace_elements = Vec::new();
-    let result =
-        contract_invocation.invoke_entrypoint(invoker, sender, payload, &mut trace_elements)?;
-    Ok((result, contract_invocation.changeset, trace_elements))
-}
-
 impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
     /// Used for handling contract entrypoint invocations internally.
     ///
@@ -74,7 +36,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
     ///  - `sender` exists
     ///  - if the contract (`contract_address`) exists, then its `module` must
     ///    also exist.
-    fn invoke_entrypoint(
+    pub(crate) fn invoke_entrypoint(
         &mut self,
         invoker: AccountAddress,
         sender: Address,
@@ -815,7 +777,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
 impl ChangeSet {
     /// Creates a new changeset with one empty [`Changes`] element on the
     /// stack..
-    fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             stack: vec![Changes {
                 contracts: BTreeMap::new(),

--- a/concordium-smart-contract-testing/src/invocation/impls.rs
+++ b/concordium-smart-contract-testing/src/invocation/impls.rs
@@ -932,9 +932,9 @@ impl ChangeSet {
     /// Returns an [`OutOfEnergy`] error if the energy needed for storing the
     /// extra state is larger than `remaining_energy`.
     ///
-    /// Otherwise, it returns
-    /// the [`Energy`] needed for storing the extra state. It also returns
-    /// whether the state of the provided `invoked_contract` has changed.
+    /// Otherwise, it returns the [`Energy`] needed for storing the extra state.
+    /// It also returns whether the state of the provided `invoked_contract`
+    /// has changed.
     pub(crate) fn collect_energy_for_state(
         mut self,
         mut remaining_energy: Energy,

--- a/concordium-smart-contract-testing/src/invocation/impls.rs
+++ b/concordium-smart-contract-testing/src/invocation/impls.rs
@@ -819,9 +819,8 @@ impl ChangeSet {
     ///  - no changes will be persisted,
     ///  - an [`OutOfEnergy`] error is returned.
     ///
-    /// Otherwise, it returns the [`Energy`] to be charged for the additional
-    /// bytes added to contract states. It also returns whether the state of the
-    /// provided `invoked_contract` was changed.
+    /// Otherwise, it returns whether the state of the provided
+    /// `invoked_contract` was changed.
     ///
     /// **Preconditions:**
     ///  - All contracts, modules, accounts referred must exist in persistence.
@@ -905,9 +904,8 @@ impl ChangeSet {
     /// Returns an [`OutOfEnergy`] error if the energy needed for storing the
     /// extra state is larger than `remaining_energy`.
     ///
-    /// Otherwise, it returns the [`Energy`] needed for storing the extra state.
-    /// It also returns whether the state of the provided `invoked_contract`
-    /// has changed.
+    /// Otherwise, it returns whether the state of the provided
+    /// `invoked_contract` has changed.
     pub(crate) fn collect_energy_for_state(
         mut self,
         remaining_energy: &mut Energy,

--- a/concordium-smart-contract-testing/src/invocation/mod.rs
+++ b/concordium-smart-contract-testing/src/invocation/mod.rs
@@ -14,5 +14,6 @@
 
 mod impls;
 mod types;
-pub(crate) use impls::invoke_entrypoint_and_get_changes;
-pub(crate) use types::{ChangeSet, InvokeEntrypointResponse, TestConfigurationError};
+pub(crate) use types::{
+    ChangeSet, EntrypointInvocationHandler, InvokeEntrypointResponse, TestConfigurationError,
+};

--- a/concordium-smart-contract-testing/src/invocation/mod.rs
+++ b/concordium-smart-contract-testing/src/invocation/mod.rs
@@ -14,4 +14,5 @@
 
 mod impls;
 mod types;
-pub(crate) use types::{EntrypointInvocationHandler, TestConfigurationError};
+pub(crate) use impls::invoke_entrypoint_and_get_changes;
+pub(crate) use types::TestConfigurationError;

--- a/concordium-smart-contract-testing/src/invocation/mod.rs
+++ b/concordium-smart-contract-testing/src/invocation/mod.rs
@@ -15,4 +15,4 @@
 mod impls;
 mod types;
 pub(crate) use impls::invoke_entrypoint_and_get_changes;
-pub(crate) use types::{TestConfigurationError, ChangeSet, InvokeEntrypointResponse};
+pub(crate) use types::{ChangeSet, InvokeEntrypointResponse, TestConfigurationError};

--- a/concordium-smart-contract-testing/src/invocation/mod.rs
+++ b/concordium-smart-contract-testing/src/invocation/mod.rs
@@ -15,4 +15,4 @@
 mod impls;
 mod types;
 pub(crate) use impls::invoke_entrypoint_and_get_changes;
-pub(crate) use types::{TestConfigurationError, ChangeSet};
+pub(crate) use types::{TestConfigurationError, ChangeSet, InvokeEntrypointResponse};

--- a/concordium-smart-contract-testing/src/invocation/mod.rs
+++ b/concordium-smart-contract-testing/src/invocation/mod.rs
@@ -15,4 +15,4 @@
 mod impls;
 mod types;
 pub(crate) use impls::invoke_entrypoint_and_get_changes;
-pub(crate) use types::TestConfigurationError;
+pub(crate) use types::{TestConfigurationError, ChangeSet};

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -1,12 +1,9 @@
-use crate::{
-    types::{Account, Contract, ContractModule},
-    AccountAddressEq,
-};
+use crate::{AccountAddressEq, Chain};
 use concordium_base::{
     base::Energy,
     contracts_common::{
-        AccountAddress, Address, Amount, ContractAddress, ExchangeRate, ModuleReference,
-        OwnedContractName, OwnedEntrypointName, SlotTime,
+        AccountAddress, Address, Amount, ContractAddress, ModuleReference, OwnedContractName,
+        OwnedEntrypointName,
     },
     smart_contracts::{ContractTraceElement, OwnedParameter},
 };
@@ -29,24 +26,10 @@ pub(crate) struct InvokeEntrypointResponse {
 pub(crate) struct EntrypointInvocationHandler<'a, 'b> {
     /// The changeset which keeps track of changes to accounts, modules, and
     /// contracts that occur during an invocation.
-    pub(super) changeset:          ChangeSet,
+    pub(super) changeset:        ChangeSet,
     /// The energy remaining for execution.
-    pub(super) remaining_energy:   &'a mut Energy,
-    /// The accounts of the chain. These are only used to look up the state
-    /// before a transaction. All changes are stored in the changeset.
-    pub(super) accounts:           &'b BTreeMap<AccountAddressEq, Account>,
-    /// The modules of the chain. These are only used to look up the state
-    /// before a transaction. All changes are stored in the changeset.
-    pub(super) modules:            &'b BTreeMap<ModuleReference, ContractModule>,
-    /// The contracts of the chain. These are only used to look up the state
-    /// before a transaction. All changes are stored in the changeset.
-    pub(super) contracts:          &'b BTreeMap<ContractAddress, Contract>,
-    /// The current block time.
-    pub(super) block_time:         SlotTime,
-    /// The euro per energy exchange rate.
-    pub(super) euro_per_energy:    ExchangeRate,
-    /// The mCCD per euro exchange rate.
-    pub(super) micro_ccd_per_euro: ExchangeRate,
+    pub(super) remaining_energy: &'a mut Energy,
+    pub(super) chain:            &'b Chain,
 }
 
 /// The set of [`Changes`] represented as a stack.

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -26,21 +26,21 @@ pub(crate) struct InvokeEntrypointResponse {
 }
 
 /// A type that supports invoking a contract entrypoint.
-pub(crate) struct EntrypointInvocationHandler<'a> {
+pub(crate) struct EntrypointInvocationHandler<'a, 'b> {
     /// The changeset which keeps track of changes to accounts, modules, and
     /// contracts that occur during an invocation.
     pub(super) changeset:          ChangeSet,
     /// The energy remaining for execution.
     pub(super) remaining_energy:   &'a mut Energy,
-    /// The accounts of the chain. These are currently clones and only used as a
-    /// reference. Any changes are saved to the changeset.
-    pub(super) accounts:           BTreeMap<AccountAddressEq, Account>,
-    /// The modules of the chain. These are currently clones and only used as a
-    /// reference. Any changes are saved to the changeset.
-    pub(super) modules:            BTreeMap<ModuleReference, ContractModule>,
-    /// The contracts of the chain. These are currently clones and only used as
-    /// a reference. Any changes are saved to the changeset.
-    pub(super) contracts:          BTreeMap<ContractAddress, Contract>,
+    /// The accounts of the chain. These are only used to look up the state
+    /// before a transaction. All changes are stored in the changeset.
+    pub(super) accounts:           &'b BTreeMap<AccountAddressEq, Account>,
+    /// The modules of the chain. These are only used to look up the state
+    /// before a transaction. All changes are stored in the changeset.
+    pub(super) modules:            &'b BTreeMap<ModuleReference, ContractModule>,
+    /// The contracts of the chain. These are only used to look up the state
+    /// before a transaction. All changes are stored in the changeset.
+    pub(super) contracts:          &'b BTreeMap<ContractAddress, Contract>,
     /// The current block time.
     pub(super) block_time:         SlotTime,
     /// The euro per energy exchange rate.
@@ -98,7 +98,7 @@ pub(super) struct ContractChanges {
 ///
 /// One `InvocationData` is created for each time
 /// [`EntrypointInvocationHandler::invoke_entrypoint`] is called.
-pub(super) struct InvocationData<'a, 'b> {
+pub(super) struct InvocationData<'a, 'b, 'c> {
     /// The invoker.
     pub(super) invoker:            AccountAddress,
     /// The sender.
@@ -115,7 +115,7 @@ pub(super) struct InvocationData<'a, 'b> {
     pub(super) parameter:          OwnedParameter,
     /// A reference to the [`EntrypointInvocationHandler`], which is used to for
     /// handling interrupts and for querying chain data.
-    pub(super) invocation_handler: &'a mut EntrypointInvocationHandler<'b>,
+    pub(super) invocation_handler: &'c mut EntrypointInvocationHandler<'a, 'b>,
     /// The current state.
     pub(super) state:              MutableState,
     /// Trace elements that have occurred during the execution.

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -61,8 +61,14 @@ pub(super) struct Changes {
 /// Data held for an account during the execution of a contract entrypoint.
 #[derive(Clone, Debug)]
 pub(super) struct AccountChanges {
+    /// The original balance.
+    ///
+    /// For the `invoker`, this will be the `original_balance - reserved_amount`
+    /// (from `EntrypointInvocationHandler`).
+    ///
     /// Should never be modified.
     pub(super) original_balance: Amount,
+    /// The change in the account balance.
     pub(super) balance_delta:    AmountDelta,
 }
 

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -1,6 +1,6 @@
-use crate::{AccountAddressEq, Chain};
+use crate::Chain;
 use concordium_base::{
-    base::Energy,
+    base::{AccountAddressEq, Energy},
     contracts_common::{
         AccountAddress, Address, Amount, ContractAddress, ModuleReference, OwnedContractName,
         OwnedEntrypointName,
@@ -52,7 +52,9 @@ pub(crate) struct ChangeSet {
 pub(super) struct Changes {
     /// The contracts which have changes.
     pub(super) contracts: BTreeMap<ContractAddress, ContractChanges>,
-    /// The accounts which have changes.
+    /// The accounts which have changes. These are indexed by account address
+    /// equivalence classes so that account aliases are resolved to the same
+    /// account.
     pub(super) accounts:  BTreeMap<AccountAddressEq, AccountChanges>,
 }
 

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -24,8 +24,15 @@ pub(crate) struct InvokeEntrypointResponse {
 
 /// A type that supports invoking a contract entrypoint.
 pub(crate) struct EntrypointInvocationHandler<'a, 'b> {
-    /// The changeset which keeps track of changes to accounts, modules, and
-    /// contracts that occur during an invocation.
+    /// Amount reserved for execution. This is used to return the correct
+    /// balance of the invoker account.
+    pub(super) reserved_amount:             Amount,
+    /// Address of the invoker of the transaction. This is used to return the
+    /// correct balance of the invoker account.
+    pub(super) invoker:                     AccountAddress,
+    /// The changeset which keeps track of
+    /// changes to accounts, modules, and contracts that occur during an
+    /// invocation.
     pub(super) changeset:        ChangeSet,
     /// The energy remaining for execution.
     pub(super) remaining_energy: &'a mut Energy,

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -26,10 +26,10 @@ pub(crate) struct InvokeEntrypointResponse {
 pub(crate) struct EntrypointInvocationHandler<'a, 'b> {
     /// Amount reserved for execution. This is used to return the correct
     /// balance of the invoker account.
-    pub(super) reserved_amount:             Amount,
+    pub(super) reserved_amount:  Amount,
     /// Address of the invoker of the transaction. This is used to return the
     /// correct balance of the invoker account.
-    pub(super) invoker:                     AccountAddress,
+    pub(super) invoker:          AccountAddress,
     /// The changeset which keeps track of
     /// changes to accounts, modules, and contracts that occur during an
     /// invocation.

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -26,17 +26,17 @@ pub(crate) struct InvokeEntrypointResponse {
 pub(crate) struct EntrypointInvocationHandler<'a, 'b> {
     /// Amount reserved for execution. This is used to return the correct
     /// balance of the invoker account.
-    pub(super) reserved_amount:  Amount,
+    pub(crate) reserved_amount:  Amount,
     /// Address of the invoker of the transaction. This is used to return the
     /// correct balance of the invoker account.
-    pub(super) invoker:          AccountAddress,
+    pub(crate) invoker:          AccountAddress,
     /// The changeset which keeps track of
     /// changes to accounts, modules, and contracts that occur during an
     /// invocation.
-    pub(super) changeset:        ChangeSet,
+    pub(crate) changeset:        ChangeSet,
     /// The energy remaining for execution.
-    pub(super) remaining_energy: &'a mut Energy,
-    pub(super) chain:            &'b Chain,
+    pub(crate) remaining_energy: &'a mut Energy,
+    pub(crate) chain:            &'b Chain,
 }
 
 /// The set of [`Changes`] represented as a stack.

--- a/concordium-smart-contract-testing/src/lib.rs
+++ b/concordium-smart-contract-testing/src/lib.rs
@@ -75,7 +75,7 @@
 mod constants;
 mod impls;
 mod invocation;
-pub mod types;
+mod types;
 pub use types::*;
 
 // Re-export types.

--- a/concordium-smart-contract-testing/src/lib.rs
+++ b/concordium-smart-contract-testing/src/lib.rs
@@ -15,7 +15,7 @@
 //! const ACC: AccountAddress = AccountAddress([0;32]);
 //!
 //! // Create an account with 10000 CCD in balance.
-//! chain.create_account(ACC, Account::new(Amount::from_ccd(1000)));
+//! chain.create_account(Account::new(ACC, Amount::from_ccd(1000)));
 //!
 //! // Deploy a smart contract module (built with [Cargo Concordium](https://developer.concordium.software/en/mainnet/smart-contracts/guides/setup-tools.html#cargo-concordium)).
 //! let deployment = chain

--- a/concordium-smart-contract-testing/src/types.rs
+++ b/concordium-smart-contract-testing/src/types.rs
@@ -40,17 +40,17 @@ pub(crate) struct ChainParameters {
 /// contracts and invoking contracts.
 #[derive(Debug)]
 pub struct Chain {
-    pub(crate) parameters: ChainParameters,
+    pub(crate) parameters:          ChainParameters,
     /// Accounts and info about them.
     /// This uses [`AccountAddressEq`] to ensure that account aliases are seen
     /// as one account.
-    pub accounts:                  BTreeMap<AccountAddressEq, Account>,
+    pub(crate) accounts:            BTreeMap<AccountAddressEq, Account>,
     /// Smart contract modules.
-    pub modules:                   BTreeMap<ModuleReference, ContractModule>,
+    pub(crate) modules:             BTreeMap<ModuleReference, ContractModule>,
     /// Smart contract instances.
-    pub contracts:                 BTreeMap<ContractAddress, Contract>,
+    pub(crate) contracts:           BTreeMap<ContractAddress, Contract>,
     /// Next contract index to use when creating a new instance.
-    pub next_contract_index:       u64,
+    pub(crate) next_contract_index: u64,
 }
 
 /// A smart contract instance.
@@ -83,6 +83,7 @@ pub struct Account {
 ///
 /// Account aliases share the first 29 bytes of the address, so the
 /// [`PartialEq`]/[`PartialOrd`] for this type adheres to that.
+// TODO: This should be moved to concordium-base.
 #[repr(transparent)]
 #[derive(Eq, Debug, Clone, Copy)]
 pub struct AccountAddressEq(pub(crate) AccountAddress);
@@ -394,10 +395,12 @@ pub struct AccountDoesNotExist {
 
 /// The provided exchange rates are not valid.
 /// Meaning that they do not correspond to one energy costing less than
-/// `u64::MAX / MAX_ALLOWED_INVOKE_ENERGY`.
-#[derive(Debug)]
+/// `u64::MAX / ` [`concordium_base::constants::MAX_ALLOWED_INVOKE_ENERGY`]`.
+#[derive(Debug, Error)]
+#[error("An exchange rate was too high.")]
 pub struct ExchangeRateError;
 
 /// A [`Signer`] cannot be created with `0` keys.
-#[derive(Debug)]
+#[derive(Debug, Error)]
+#[error("Any signer must have at least one key.")]
 pub struct ZeroKeysError;

--- a/concordium-smart-contract-testing/src/types.rs
+++ b/concordium-smart-contract-testing/src/types.rs
@@ -71,6 +71,7 @@ pub struct Contract {
 /// An account.
 #[derive(Clone, Debug)]
 pub struct Account {
+    pub address: AccountAddress,
     /// The account balance.
     pub balance: AccountBalance,
     /// Account policy.

--- a/concordium-smart-contract-testing/src/types.rs
+++ b/concordium-smart-contract-testing/src/types.rs
@@ -1,5 +1,5 @@
 use concordium_base::{
-    base::Energy,
+    base::{AccountAddressEq, Energy},
     contracts_common::{
         AccountAddress, AccountBalance, Address, Amount, ContractAddress, ExchangeRate,
         ModuleReference, OwnedContractName, OwnedEntrypointName, OwnedPolicy, SlotTime,
@@ -77,16 +77,6 @@ pub struct Account {
     /// Account policy.
     pub policy:  OwnedPolicy,
 }
-
-/// A helper struct that is used to ensure that aliases of an account are seen
-/// as being the same account.
-///
-/// Account aliases share the first 29 bytes of the address, so the
-/// [`PartialEq`]/[`PartialOrd`] for this type adheres to that.
-// TODO: This should be moved to concordium-base.
-#[repr(transparent)]
-#[derive(Eq, Debug, Clone, Copy)]
-pub struct AccountAddressEq(pub(crate) AccountAddress);
 
 /// A signer with a number of keys, the amount of which affects the cost of
 /// transactions.

--- a/concordium-smart-contract-testing/src/types.rs
+++ b/concordium-smart-contract-testing/src/types.rs
@@ -20,11 +20,8 @@ pub struct ContractModule {
     pub(crate) artifact: Arc<artifact::Artifact<v1::ProcessedImports, artifact::CompiledFunction>>,
 }
 
-/// Represents the blockchain and supports a number of operations, including
-/// creating accounts, deploying modules, initializing contract, updating
-/// contracts and invoking contracts.
 #[derive(Debug)]
-pub struct Chain {
+pub(crate) struct ChainParameters {
     /// The block time viewable inside the smart contracts.
     /// Defaults to `0`.
     pub block_time:                SlotTime,
@@ -36,6 +33,14 @@ pub struct Chain {
     // This is not public because we ensure a reasonable value during the construction of the
     // [`Chain`].
     pub(crate) euro_per_energy:    ExchangeRate,
+}
+
+/// Represents the blockchain and supports a number of operations, including
+/// creating accounts, deploying modules, initializing contract, updating
+/// contracts and invoking contracts.
+#[derive(Debug)]
+pub struct Chain {
+    pub(crate) parameters: ChainParameters,
     /// Accounts and info about them.
     /// This uses [`AccountAddressEq`] to ensure that account aliases are seen
     /// as one account.

--- a/concordium-smart-contract-testing/tests/all_new_host_functions.rs
+++ b/concordium-smart-contract-testing/tests/all_new_host_functions.rs
@@ -12,7 +12,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test_all_new_host_functions() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     chain
         .module_deploy_v1(Signer::with_one_key(),

--- a/concordium-smart-contract-testing/tests/all_new_host_functions.rs
+++ b/concordium-smart-contract-testing/tests/all_new_host_functions.rs
@@ -15,9 +15,11 @@ fn test_all_new_host_functions() {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
-            Chain::module_load_v1_raw(format!("{}/all-new-host-functions.wasm", WASM_TEST_FOLDER)).expect("module should exist"),
+            Chain::module_load_v1_raw(format!("{}/all-new-host-functions.wasm", WASM_TEST_FOLDER))
+                .expect("module should exist"),
         )
         .expect("Deploying valid module should work");
 }

--- a/concordium-smart-contract-testing/tests/basics.rs
+++ b/concordium-smart-contract-testing/tests/basics.rs
@@ -9,7 +9,7 @@ const ACC_1: AccountAddress = AccountAddress([1; 32]);
 fn deploying_valid_module_works() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res = chain
         .module_deploy_v1(
@@ -33,7 +33,7 @@ fn deploying_valid_module_works() {
 fn initializing_valid_contract_works() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(
@@ -70,7 +70,7 @@ fn initializing_valid_contract_works() {
 fn initializing_with_invalid_parameter_fails() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(
@@ -116,7 +116,7 @@ fn initializing_with_invalid_parameter_fails() {
 fn updating_valid_contract_works() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(
@@ -196,7 +196,7 @@ fn updating_valid_contract_works() {
 fn updating_and_invoking_with_missing_sender_fails() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let missing_account = Address::Account(ACC_1);
     let missing_contract = Address::Contract(ContractAddress::new(100, 0));
@@ -304,7 +304,7 @@ fn updating_and_invoking_with_missing_sender_fails() {
 fn init_with_less_energy_than_module_lookup() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(
@@ -342,7 +342,7 @@ fn init_with_less_energy_than_module_lookup() {
 fn update_with_fib_reentry_works() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(

--- a/concordium-smart-contract-testing/tests/basics.rs
+++ b/concordium-smart-contract-testing/tests/basics.rs
@@ -22,7 +22,7 @@ fn deploying_valid_module_works() {
         )
         .expect("Deploying valid module should work.");
 
-    assert_eq!(chain.modules.len(), 1);
+    assert!(chain.get_module(res.module_reference).is_some());
     assert_eq!(
         chain.account_balance_available(ACC_0),
         Some(initial_balance - res.transaction_fee)
@@ -63,7 +63,7 @@ fn initializing_valid_contract_works() {
         chain.account_balance_available(ACC_0),
         Some(initial_balance - res_deploy.transaction_fee - res_init.transaction_fee)
     );
-    assert_eq!(chain.contracts.len(), 1);
+    assert!(chain.get_contract(ContractAddress::new(0,0)).is_some());
 }
 
 #[test]
@@ -185,7 +185,7 @@ fn updating_valid_contract_works() {
                 - res_update.transaction_fee
         )
     );
-    assert_eq!(chain.contracts.len(), 1);
+    assert!(chain.get_contract(res_init.contract_address).is_some());
     assert!(res_update.state_changed);
     // Assert that the updated state is persisted.
     assert_eq!(res_invoke_get.return_value, [1u8]);
@@ -406,7 +406,7 @@ fn update_with_fib_reentry_works() {
                 - res_update.transaction_fee
         )
     );
-    assert_eq!(chain.contracts.len(), 1);
+    assert!(chain.get_contract(res_init.contract_address).is_some());
     assert!(res_update.state_changed);
     let expected_res = u64::to_le_bytes(13);
     assert_eq!(res_update.return_value, expected_res);

--- a/concordium-smart-contract-testing/tests/basics.rs
+++ b/concordium-smart-contract-testing/tests/basics.rs
@@ -63,7 +63,7 @@ fn initializing_valid_contract_works() {
         chain.account_balance_available(ACC_0),
         Some(initial_balance - res_deploy.transaction_fee - res_init.transaction_fee)
     );
-    assert!(chain.get_contract(ContractAddress::new(0,0)).is_some());
+    assert!(chain.get_contract(ContractAddress::new(0, 0)).is_some());
 }
 
 #[test]

--- a/concordium-smart-contract-testing/tests/checkpointing.rs
+++ b/concordium-smart-contract-testing/tests/checkpointing.rs
@@ -27,7 +27,8 @@ fn test_case_1() {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/checkpointing.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -35,21 +36,31 @@ fn test_case_1() {
         .expect("Deploying valid module should work");
 
     let res_init_a = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_a".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_a".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     let res_init_b = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_b".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_b".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     let forward_parameter = (
@@ -68,7 +79,8 @@ fn test_case_1() {
     );
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -105,7 +117,8 @@ fn test_case_2() {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/checkpointing.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -113,21 +126,31 @@ fn test_case_2() {
         .expect("Deploying valid module should work");
 
     let res_init_a = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_a".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_a".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     let res_init_b = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_b".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_b".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     let forward_parameter = (
@@ -146,7 +169,8 @@ fn test_case_2() {
     );
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -183,7 +207,8 @@ fn test_case_3() {
     chain.create_account(Account::new(ACC_1, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/checkpointing.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -191,25 +216,36 @@ fn test_case_3() {
         .expect("Deploying valid module should work");
 
     let res_init_a = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_a".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_a".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_b".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_b".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -244,7 +280,8 @@ fn test_case_4() {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/checkpointing.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -252,21 +289,31 @@ fn test_case_4() {
         .expect("Deploying valid module should work");
 
     let res_init_a = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_a".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_a".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     let res_init_b = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_b".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_b".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     let forward_parameter = (
@@ -285,7 +332,8 @@ fn test_case_4() {
     );
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),

--- a/concordium-smart-contract-testing/tests/checkpointing.rs
+++ b/concordium-smart-contract-testing/tests/checkpointing.rs
@@ -24,7 +24,7 @@ const ACC_1: AccountAddress = AccountAddress([1; 32]);
 fn test_case_1() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),
@@ -102,7 +102,7 @@ fn test_case_1() {
 fn test_case_2() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),
@@ -179,8 +179,8 @@ fn test_case_2() {
 fn test_case_3() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
-    chain.create_account(ACC_1, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
+    chain.create_account(Account::new(ACC_1, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),
@@ -241,7 +241,7 @@ fn test_case_3() {
 fn test_case_4() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),

--- a/concordium-smart-contract-testing/tests/counter.rs
+++ b/concordium-smart-contract-testing/tests/counter.rs
@@ -11,7 +11,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test_counter() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),

--- a/concordium-smart-contract-testing/tests/counter.rs
+++ b/concordium-smart-contract-testing/tests/counter.rs
@@ -14,7 +14,8 @@ fn test_counter() {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/call-counter.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -22,16 +23,22 @@ fn test_counter() {
         .expect("Deploying valid module should work");
 
     let res_init = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_counter".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_counter".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -46,7 +53,8 @@ fn test_counter() {
     assert_counter_state(&mut chain, res_init.contract_address, 1);
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -67,7 +75,8 @@ fn test_counter() {
         Amount::zero(),
     );
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),

--- a/concordium-smart-contract-testing/tests/error_codes.rs
+++ b/concordium-smart-contract-testing/tests/error_codes.rs
@@ -14,7 +14,8 @@ fn test_error_codes() {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/caller.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -22,12 +23,17 @@ fn test_error_codes() {
         .expect("Deploying valid module should work");
 
     let res_init = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_caller".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_caller".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     // Invoke an entrypoint that calls the "fail" entrypoint.
@@ -46,7 +52,8 @@ fn test_error_codes() {
         Amount::zero(),
     );
     let res_update_0 = chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -79,7 +86,8 @@ fn test_error_codes() {
         Amount::from_micro_ccd(10_000),
     );
     let res_update_1 = chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -110,7 +118,8 @@ fn test_error_codes() {
         Amount::zero(),
     );
     let res_update_2 = chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -143,7 +152,8 @@ fn test_error_codes() {
         Amount::zero(),
     );
     let res_update_3 = chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -176,7 +186,8 @@ fn test_error_codes() {
         Amount::zero(),
     );
     let res_update_4 = chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -212,7 +223,8 @@ fn test_error_codes() {
         Amount::zero(),
     );
     let res_update_6 = chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),

--- a/concordium-smart-contract-testing/tests/error_codes.rs
+++ b/concordium-smart-contract-testing/tests/error_codes.rs
@@ -11,7 +11,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test_error_codes() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),

--- a/concordium-smart-contract-testing/tests/fallback.rs
+++ b/concordium-smart-contract-testing/tests/fallback.rs
@@ -9,7 +9,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test_fallback() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(

--- a/concordium-smart-contract-testing/tests/iterator.rs
+++ b/concordium-smart-contract-testing/tests/iterator.rs
@@ -13,7 +13,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test_iterator() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),

--- a/concordium-smart-contract-testing/tests/iterator.rs
+++ b/concordium-smart-contract-testing/tests/iterator.rs
@@ -16,7 +16,8 @@ fn test_iterator() {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/iterator.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -24,16 +25,22 @@ fn test_iterator() {
         .expect("Deploying valid module should work");
 
     let res_init = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_iterator".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_iterator".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -46,7 +53,8 @@ fn test_iterator() {
         )
         .expect("Should succeed");
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),

--- a/concordium-smart-contract-testing/tests/queries.rs
+++ b/concordium-smart-contract-testing/tests/queries.rs
@@ -20,8 +20,8 @@ mod query_account_balance {
     fn test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
-        chain.create_account(ACC_1, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
+        chain.create_account(Account::new(ACC_1, initial_balance));
 
         let res_deploy = chain
             .module_deploy_v1(
@@ -90,8 +90,8 @@ mod query_account_balance {
     fn invoker_test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
-        chain.create_account(ACC_1, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
+        chain.create_account(Account::new(ACC_1, initial_balance));
 
         let res_deploy = chain
             .module_deploy_v1(
@@ -165,8 +165,8 @@ mod query_account_balance {
     fn transfer_test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
-        chain.create_account(ACC_1, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
+        chain.create_account(Account::new(ACC_1, initial_balance));
 
         let res_deploy = chain
             .module_deploy_v1(
@@ -248,8 +248,8 @@ mod query_account_balance {
     fn balance_test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
-        chain.create_account(ACC_1, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
+        chain.create_account(Account::new(ACC_1, initial_balance));
 
         let res_deploy = chain
             .module_deploy_v1(
@@ -317,7 +317,7 @@ mod query_account_balance {
     fn missing_account_test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
 
         let res_deploy = chain
             .module_deploy_v1(
@@ -388,7 +388,7 @@ mod query_contract_balance {
     fn test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
 
         let init_amount = Amount::from_ccd(123);
 
@@ -462,7 +462,7 @@ mod query_contract_balance {
     fn query_self_test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
 
         let init_amount = Amount::from_ccd(123);
         let update_amount = Amount::from_ccd(456);
@@ -522,7 +522,7 @@ mod query_contract_balance {
     fn query_self_after_transfer_test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
 
         let init_amount = Amount::from_ccd(123);
         let update_amount = Amount::from_ccd(456);
@@ -590,7 +590,7 @@ mod query_contract_balance {
     fn missing_contract_test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
 
         let res_deploy = chain
             .module_deploy_v1(
@@ -652,7 +652,7 @@ mod query_exchange_rates {
     fn test() {
         let mut chain = Chain::new();
         let initial_balance = Amount::from_ccd(1000000);
-        chain.create_account(ACC_0, Account::new(initial_balance));
+        chain.create_account(Account::new(ACC_0, initial_balance));
 
         let res_deploy = chain
             .module_deploy_v1(

--- a/concordium-smart-contract-testing/tests/recorder.rs
+++ b/concordium-smart-contract-testing/tests/recorder.rs
@@ -9,7 +9,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test_recorder() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),

--- a/concordium-smart-contract-testing/tests/recorder.rs
+++ b/concordium-smart-contract-testing/tests/recorder.rs
@@ -12,7 +12,8 @@ fn test_recorder() {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/record-parameters.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -20,16 +21,22 @@ fn test_recorder() {
         .expect("Deploying valid module should work");
 
     let res_init = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_recorder".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_recorder".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(100000),
@@ -43,7 +50,8 @@ fn test_recorder() {
         )
         .expect("Update failed");
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(100000),

--- a/concordium-smart-contract-testing/tests/relaxed_restrictions.rs
+++ b/concordium-smart-contract-testing/tests/relaxed_restrictions.rs
@@ -26,7 +26,8 @@ fn test_new_parameter_limit() {
     let parameter = mk_parameter(65535, 65535);
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/relaxed-restrictions.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -34,16 +35,22 @@ fn test_new_parameter_limit() {
         .expect("Deploying valid module should work");
 
     let res_init = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(80000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_relax".into()),
-            param:     parameter.clone(), // Check parameter size limit on init.
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(80000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_relax".into()),
+                param:     parameter.clone(), // Check parameter size limit on init.
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(700000),
@@ -63,7 +70,8 @@ fn test_new_return_value_limit() {
     let (mut chain, contract_address) = deploy_and_init();
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -84,7 +92,8 @@ fn test_new_log_limit() {
     let (mut chain, contract_address) = deploy_and_init();
 
     chain
-        .contract_update(Signer::with_one_key(),
+        .contract_update(
+            Signer::with_one_key(),
             ACC_0,
             Address::Account(ACC_0),
             Energy::from(10000),
@@ -107,7 +116,8 @@ fn deploy_and_init() -> (Chain, ContractAddress) {
     chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
-        .module_deploy_v1(Signer::with_one_key(),
+        .module_deploy_v1(
+            Signer::with_one_key(),
             ACC_0,
             Chain::module_load_v1_raw(format!("{}/relaxed-restrictions.wasm", WASM_TEST_FOLDER))
                 .expect("module should exist"),
@@ -115,12 +125,17 @@ fn deploy_and_init() -> (Chain, ContractAddress) {
         .expect("Deploying valid module should work");
 
     let res_init = chain
-        .contract_init(Signer::with_one_key(), ACC_0, Energy::from(10000), InitContractPayload {
-            mod_ref:   res_deploy.module_reference,
-            init_name: OwnedContractName::new_unchecked("init_relax".into()),
-            param:     OwnedParameter::empty(),
-            amount:    Amount::zero(),
-        })
+        .contract_init(
+            Signer::with_one_key(),
+            ACC_0,
+            Energy::from(10000),
+            InitContractPayload {
+                mod_ref:   res_deploy.module_reference,
+                init_name: OwnedContractName::new_unchecked("init_relax".into()),
+                param:     OwnedParameter::empty(),
+                amount:    Amount::zero(),
+            },
+        )
         .expect("Initializing valid contract should work");
     (chain, res_init.contract_address)
 }

--- a/concordium-smart-contract-testing/tests/relaxed_restrictions.rs
+++ b/concordium-smart-contract-testing/tests/relaxed_restrictions.rs
@@ -21,7 +21,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test_new_parameter_limit() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let parameter = mk_parameter(65535, 65535);
 
@@ -104,7 +104,7 @@ fn test_new_log_limit() {
 fn deploy_and_init() -> (Chain, ContractAddress) {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(Signer::with_one_key(),

--- a/concordium-smart-contract-testing/tests/self_balance.rs
+++ b/concordium-smart-contract-testing/tests/self_balance.rs
@@ -99,7 +99,7 @@ fn deploy_and_init(
 ) -> (Chain, ContractAddress, ModuleReference) {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(

--- a/concordium-smart-contract-testing/tests/transfer.rs
+++ b/concordium-smart-contract-testing/tests/transfer.rs
@@ -54,7 +54,7 @@ fn test_transfer() {
     // Contract should have forwarded the amount and thus have balance == 0.
     assert_eq!(
         Amount::zero(),
-        chain.contracts.get(&contract_address).unwrap().self_balance
+        chain.get_contract(contract_address).unwrap().self_balance
     );
 
     // Deposit 1000 micro CCD.
@@ -94,7 +94,7 @@ fn test_transfer() {
     // Contract should have 1000 - 17 microCCD in balance.
     assert_eq!(
         Amount::from_micro_ccd(1000 - 17),
-        chain.contracts.get(&contract_address).unwrap().self_balance
+        chain.get_contract(contract_address).unwrap().self_balance
     );
     assert_eq!(res_update.trace_elements[..], [
         ContractTraceElement::Interrupted {

--- a/concordium-smart-contract-testing/tests/transfer.rs
+++ b/concordium-smart-contract-testing/tests/transfer.rs
@@ -9,7 +9,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test_transfer() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(10000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(

--- a/concordium-smart-contract-testing/tests/upgrades.rs
+++ b/concordium-smart-contract-testing/tests/upgrades.rs
@@ -11,7 +11,7 @@ const ACC_0: AccountAddress = AccountAddress([0; 32]);
 fn test() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     // Deploy the two modules `upgrading_0`, `upgrading_1`
     let res_deploy_0 = chain
@@ -101,7 +101,7 @@ fn test() {
 fn test_self_invoke() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy_0 = chain
         .module_deploy_v1(
@@ -175,7 +175,7 @@ fn test_self_invoke() {
 fn test_missing_module() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(
@@ -233,7 +233,7 @@ fn test_missing_module() {
 fn test_missing_contract() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy_0 = chain
         .module_deploy_v1(
@@ -304,7 +304,7 @@ fn test_missing_contract() {
 fn test_twice_in_one_transaction() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy_0 = chain
         .module_deploy_v1(
@@ -402,7 +402,7 @@ fn test_twice_in_one_transaction() {
 fn test_chained_contract() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy = chain
         .module_deploy_v1(
@@ -462,7 +462,7 @@ fn test_chained_contract() {
 fn test_reject() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy_0 = chain
         .module_deploy_v1(
@@ -553,7 +553,7 @@ fn test_reject() {
 fn test_changing_entrypoint() {
     let mut chain = Chain::new();
     let initial_balance = Amount::from_ccd(1000000);
-    chain.create_account(ACC_0, Account::new(initial_balance));
+    chain.create_account(Account::new(ACC_0, initial_balance));
 
     let res_deploy_0 = chain
         .module_deploy_v1(


### PR DESCRIPTION
## Purpose

In lieu of review of #23 

## Changes 

- Remove the need to clone all accounts, contracts, modules when executing contracts. Only references are passed in.
- Make contract_invoke require an immutable reference only.
- Avoid mutating the state of an account before execution. Instead remember which account is being updated for correct balance queries. This is cleaner and makes it simpler to enforce transactionality since any errors in execution will automatically not update the Chain structure.
- Hide internals of the Chain struct, instead expose the relevant accessors.
- Fixes in a number of documentation links.
- Misc improvements.

TODO
- [ ] The next_contract_index as it is now is not ideal. With hidden fields of the Chain it is OK, since initializing is the only way to add new contracts. But in this case we don't need it either.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.