### PR TITLE
Use cargo metadata in cargo-concordium instead of parsing manifest

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Support calling `cargo concordium build` and `cargo concordium test` from a project subdirectory.
+
 ## 2.7.0
 
 - Add `schema-base64` command to convert a given schema to base64 format.

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -211,13 +211,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde 1.0.152",
+]
+
+[[package]]
 name = "cargo-concordium"
 version = "2.7.0"
 dependencies = [
  "ansi_term",
  "anyhow",
  "base64",
- "cargo_toml",
+ "cargo_metadata",
  "clap",
  "concordium-contracts-common",
  "criterion",
@@ -234,14 +243,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo_toml"
-version = "0.11.8"
+name = "cargo-platform"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c3ff59e3b7d24630206bb63a73af65da4ed5df1f76ee84dfafb9fee2ba60e"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
 dependencies = [
  "serde 1.0.152",
- "serde_derive",
- "toml",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08a1ec454bc3eead8719cb56e15dbbfecdbc14e4b3a3ae4936cc6e31f5fc0d07"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde 1.0.152",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1384,6 +1405,9 @@ name = "semver"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
+dependencies = [
+ "serde 1.0.152",
+]
 
 [[package]]
 name = "serde"

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -13,14 +13,14 @@ structopt = "0.3"
 hex = "0.4"
 base64= "0.21"
 serde = "1.0"
-serde_json="1.0.56"
-cargo_toml = "0.11.5"
-anyhow = "1.0.33"
+serde_json="1.0"
+anyhow = "1.0"
 ansi_term = "0.12"
 ptree = "0.4"
 strsim = "0.10"
-which = "4.3.0"
+which = "4.3"
 rand = { version = "=0.7", features = ["small_rng"] }
+cargo_metadata = "0.15"
 
 [dependencies.wasm-transform]
 path = "../concordium-base/smart-contracts/wasm-transform"


### PR DESCRIPTION
## Purpose

Use `cargo_metadata` in `cargo-concordium` instead of parsing package manifest.

Commands such as `cargo concordium build` can now be called from a project subdirectory, where before it was required to be called in the same directory as the `Cargo.toml`.

Additionally, `cargo-concordium` uses the target directory from cargo metadata, instead of the hard-coded `target`.

## Changes

**cargo-concordium**

- Replace `cargo_toml` dependency with `cargo_metadata`.
- Remove patch versions of dependencies in Cargo.toml.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
