### PR TITLE
Simplifications and helpers

### DIFF
--- a/concordium-smart-contract-testing/src/impls.rs
+++ b/concordium-smart-contract-testing/src/impls.rs
@@ -685,7 +685,6 @@ impl Chain {
                     return_value: data.unwrap_or_default(),
                     state_changed,
                     new_balance,
-                    events: contract_events_from_logs(result.logs),
                 })
             }
             v1::InvokeResponse::Failure { kind } => Err(self.convert_to_invoke_error(

--- a/concordium-smart-contract-testing/src/impls.rs
+++ b/concordium-smart-contract-testing/src/impls.rs
@@ -1,8 +1,6 @@
 use crate::{
     constants,
-    invocation::{
-        ChangeSet, EntrypointInvocationHandler, InvokeEntrypointResponse, TestConfigurationError,
-    },
+    invocation::{ChangeSet, EntrypointInvocationHandler, TestConfigurationError},
     types::*,
 };
 use anyhow::anyhow;
@@ -19,7 +17,11 @@ use concordium_base::{
     },
     transactions::{self, cost, InitContractPayload, UpdateContractPayload},
 };
-use concordium_smart_contract_engine::{v0, v1, InterpreterEnergy};
+use concordium_smart_contract_engine::{
+    v0,
+    v1::{self, InvokeResponse},
+    InterpreterEnergy,
+};
 use num_bigint::BigUint;
 use num_integer::Integer;
 use std::{collections::BTreeMap, path::Path, sync::Arc};
@@ -603,14 +605,7 @@ impl Chain {
         amount_reserved_for_energy: Amount,
         payload: UpdateContractPayload,
         remaining_energy: &mut Energy,
-    ) -> Result<
-        (
-            InvokeEntrypointResponse,
-            ChangeSet,
-            Vec<ContractTraceElement>,
-        ),
-        ContractInvokeError,
-    > {
+    ) -> Result<(InvokeResponse, ChangeSet, Vec<ContractTraceElement>), ContractInvokeError> {
         // Check if the contract to invoke exists.
         if !self.contract_exists(payload.address) {
             return Err(self.convert_to_invoke_error(
@@ -668,13 +663,13 @@ impl Chain {
 
     fn contract_invocation_process_response(
         &self,
-        result: InvokeEntrypointResponse,
+        result: InvokeResponse,
         trace_elements: Vec<ContractTraceElement>,
         energy_reserved: Energy,
         remaining_energy: Energy,
         state_changed: bool,
     ) -> Result<ContractInvokeSuccess, ContractInvokeError> {
-        match result.invoke_response {
+        match result {
             v1::InvokeResponse::Success { new_balance, data } => {
                 let energy_used = energy_reserved - remaining_energy;
                 let transaction_fee = self.parameters.calculate_energy_cost(energy_used);
@@ -786,7 +781,7 @@ impl Chain {
             Ok((result, changeset, trace_elements)) => {
                 // Charge energy for contract storage. Or return an error if out
                 // of energy.
-                let state_changed = if result.is_success() {
+                let state_changed = if matches!(result, v1::InvokeResponse::Success { .. }) {
                     let res = changeset.persist(
                         &mut remaining_energy,
                         contract_address,
@@ -889,7 +884,7 @@ impl Chain {
             Ok((result, changeset, trace_elements)) => {
                 // Charge energy for contract storage. Or return an error if out
                 // of energy.
-                let state_changed = if result.is_success() {
+                let state_changed = if matches!(result, v1::InvokeResponse::Success { .. }) {
                     changeset
                         .collect_energy_for_state(&mut remaining_energy, contract_address)
                         .map_err(|_| self.invocation_out_of_energy_error(energy_reserved))?

--- a/concordium-smart-contract-testing/src/invocation/impls.rs
+++ b/concordium-smart-contract-testing/src/invocation/impls.rs
@@ -61,7 +61,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
         payload: UpdateContractPayload,
         trace_elements_checkpoint: usize,
     ) -> Result<
-        Result<(v1::ReceiveResult<CompiledFunction>, InvocationData), InvokeEntrypointResponse>,
+        Result<(v1::ReceiveResult<CompiledFunction>, InvocationData), InvokeResponse>,
         TestConfigurationError,
     > {
         // Charge the base cost for updating a contract.
@@ -99,9 +99,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                         TransferError::ToMissing => v1::InvokeFailure::NonExistentContract,
                     };
                     // Return early.
-                    return Ok(Err(InvokeEntrypointResponse {
-                        invoke_response: v1::InvokeResponse::Failure { kind },
-                    }));
+                    return Ok(Err(v1::InvokeResponse::Failure { kind }));
                 }
             }
         } else {
@@ -109,10 +107,8 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                 Some(self_balance) => self_balance,
                 None => {
                     // Return early.
-                    return Ok(Err(InvokeEntrypointResponse {
-                        invoke_response: v1::InvokeResponse::Failure {
-                            kind: v1::InvokeFailure::NonExistentContract,
-                        },
+                    return Ok(Err(v1::InvokeResponse::Failure {
+                        kind: v1::InvokeFailure::NonExistentContract,
                     }));
                 }
             }
@@ -154,10 +150,8 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                 )
             } else {
                 // Return early.
-                return Ok(Err(InvokeEntrypointResponse {
-                    invoke_response: v1::InvokeResponse::Failure {
-                        kind: v1::InvokeFailure::NonExistentEntrypoint,
-                    },
+                return Ok(Err(v1::InvokeResponse::Failure {
+                    kind: v1::InvokeFailure::NonExistentEntrypoint,
                 }));
             }
         };
@@ -247,7 +241,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
         invoker: AccountAddress,
         sender: Address,
         payload: UpdateContractPayload,
-    ) -> Result<(InvokeEntrypointResponse, Vec<ContractTraceElement>), TestConfigurationError> {
+    ) -> Result<(InvokeResponse, Vec<ContractTraceElement>), TestConfigurationError> {
         let mut stack = Vec::new();
         let mut trace_elements = Vec::new();
         stack.push(Next::Initial {
@@ -257,7 +251,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
         });
         // Initialized to a dummy value. This will always be set or the function will
         // terminate with an Err.
-        let mut invoke_response: Option<InvokeEntrypointResponse> = None;
+        let mut invoke_response: Option<InvokeResponse> = None;
         while let Some(invocation_data) = stack.pop() {
             let (receive_result, mut invocation_data) = match invocation_data {
                 Next::Resume {
@@ -288,7 +282,6 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                             let (success, call_response) = match invoke_response
                                 .take()
                                 .expect("Response should be available")
-                                .invoke_response
                             {
                                 v1::InvokeResponse::Success {
                                     data: return_value, ..
@@ -406,11 +399,9 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                         );
                     }
 
-                    invoke_response = Some(InvokeEntrypointResponse {
-                        invoke_response: v1::InvokeResponse::Success {
-                            new_balance: self.contract_balance_unchecked(invocation_data.address),
-                            data:        Some(return_value),
-                        },
+                    invoke_response = Some(v1::InvokeResponse::Success {
+                        new_balance: self.contract_balance_unchecked(invocation_data.address),
+                        data:        Some(return_value),
                     });
                 }
                 v1::ReceiveResult::Interrupt {
@@ -715,12 +706,10 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                     // Delete the trace of the failed part of the execution.
                     // This is the current behaviour of the on-chain execution.
                     trace_elements.truncate(invocation_data.trace_elements_checkpoint);
-                    invoke_response = Some(InvokeEntrypointResponse {
-                        invoke_response: v1::InvokeResponse::Failure {
-                            kind: v1::InvokeFailure::ContractReject {
-                                code: reason,
-                                data: return_value,
-                            },
+                    invoke_response = Some(v1::InvokeResponse::Failure {
+                        kind: v1::InvokeFailure::ContractReject {
+                            code: reason,
+                            data: return_value,
                         },
                     });
                 }
@@ -732,10 +721,8 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                     // Delete the trace of the failed part of the execution.
                     // This is the current behaviour of the on-chain execution.
                     trace_elements.truncate(invocation_data.trace_elements_checkpoint);
-                    invoke_response = Some(InvokeEntrypointResponse {
-                        invoke_response: v1::InvokeResponse::Failure {
-                            kind: v1::InvokeFailure::RuntimeError,
-                        },
+                    invoke_response = Some(v1::InvokeResponse::Failure {
+                        kind: v1::InvokeFailure::RuntimeError,
                     });
                 }
                 // Convert this to an error here, so that we will short circuit processing.
@@ -1500,13 +1487,6 @@ impl AccountChanges {
         self.balance_delta
             .apply_to_balance(self.original_balance)
             .expect("Precondition violation: invalid `balance_delta`.")
-    }
-}
-
-impl InvokeEntrypointResponse {
-    /// Whether the invoke was successful.
-    pub(crate) fn is_success(&self) -> bool {
-        matches!(self.invoke_response, v1::InvokeResponse::Success { .. })
     }
 }
 

--- a/concordium-smart-contract-testing/src/invocation/impls.rs
+++ b/concordium-smart-contract-testing/src/invocation/impls.rs
@@ -101,7 +101,6 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                     // Return early.
                     return Ok(Err(InvokeEntrypointResponse {
                         invoke_response: v1::InvokeResponse::Failure { kind },
-                        logs:            v0::Logs::new(),
                     }));
                 }
             }
@@ -114,7 +113,6 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                         invoke_response: v1::InvokeResponse::Failure {
                             kind: v1::InvokeFailure::NonExistentContract,
                         },
-                        logs:            v0::Logs::new(),
                     }));
                 }
             }
@@ -160,7 +158,6 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                     invoke_response: v1::InvokeResponse::Failure {
                         kind: v1::InvokeFailure::NonExistentEntrypoint,
                     },
-                    logs:            v0::Logs::new(),
                 }));
             }
         };
@@ -395,7 +392,7 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                                 invocation_data.contract_name.as_contract_name(),
                                 invocation_data.entrypoint.as_entrypoint_name(),
                             ),
-                            events:           contract_events_from_logs(logs.clone()),
+                            events:           contract_events_from_logs(logs),
                         },
                     };
                     // Add update event
@@ -414,7 +411,6 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                             new_balance: self.contract_balance_unchecked(invocation_data.address),
                             data:        Some(return_value),
                         },
-                        logs,
                     });
                 }
                 v1::ReceiveResult::Interrupt {
@@ -726,7 +722,6 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                                 data: return_value,
                             },
                         },
-                        logs:            v0::Logs::new(),
                     });
                 }
                 v1::ReceiveResult::Trap {
@@ -741,7 +736,6 @@ impl<'a, 'b> EntrypointInvocationHandler<'a, 'b> {
                         invoke_response: v1::InvokeResponse::Failure {
                             kind: v1::InvokeFailure::RuntimeError,
                         },
-                        logs:            v0::Logs::new(),
                     });
                 }
                 // Convert this to an error here, so that we will short circuit processing.

--- a/concordium-smart-contract-testing/src/invocation/mod.rs
+++ b/concordium-smart-contract-testing/src/invocation/mod.rs
@@ -14,6 +14,4 @@
 
 mod impls;
 mod types;
-pub(crate) use types::{
-    ChangeSet, EntrypointInvocationHandler, InvokeEntrypointResponse, TestConfigurationError,
-};
+pub(crate) use types::{ChangeSet, EntrypointInvocationHandler, TestConfigurationError};

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -7,15 +7,8 @@ use concordium_base::{
     },
     smart_contracts::OwnedParameter,
 };
-use concordium_smart_contract_engine::v1::{trie::MutableState, InvokeResponse};
+use concordium_smart_contract_engine::v1::trie::MutableState;
 use std::collections::BTreeMap;
-
-/// The response from invoking an entrypoint.
-#[derive(Debug)]
-pub(crate) struct InvokeEntrypointResponse {
-    /// The result from the invoke.
-    pub(crate) invoke_response: InvokeResponse,
-}
 
 /// A type that supports invoking a contract entrypoint.
 pub(crate) struct EntrypointInvocationHandler<'a, 'b> {

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -7,10 +7,7 @@ use concordium_base::{
     },
     smart_contracts::OwnedParameter,
 };
-use concordium_smart_contract_engine::{
-    v0,
-    v1::{trie::MutableState, InvokeResponse},
-};
+use concordium_smart_contract_engine::v1::{trie::MutableState, InvokeResponse};
 use std::collections::BTreeMap;
 
 /// The response from invoking an entrypoint.
@@ -18,9 +15,6 @@ use std::collections::BTreeMap;
 pub(crate) struct InvokeEntrypointResponse {
     /// The result from the invoke.
     pub(crate) invoke_response: InvokeResponse,
-    /// Logs created during the invocation.
-    /// Has entries if and only if `invoke_response` is `Success`.
-    pub(crate) logs:            v0::Logs,
 }
 
 /// A type that supports invoking a contract entrypoint.
@@ -65,7 +59,7 @@ pub(super) struct AccountChanges {
     /// The original balance.
     ///
     /// For the `invoker`, this will be the `original_balance - reserved_amount`
-    /// (from `EntrypointInvocationHandler`).
+    /// (from [`EntrypointInvocationHandler`]).
     ///
     /// Should never be modified.
     pub(super) original_balance: Amount,

--- a/concordium-smart-contract-testing/src/types.rs
+++ b/concordium-smart-contract-testing/src/types.rs
@@ -277,8 +277,37 @@ pub struct ContractInvokeSuccess {
     pub state_changed:   bool,
     /// The new balance of the smart contract.
     pub new_balance:     Amount,
-    /// The contract events (logs) produced since the last interrupt.
-    pub events:          Vec<ContractEvent>,
+}
+
+impl ContractInvokeSuccess {
+    /// Extract all the events logged by all the contracts in the invocation.
+    /// The events are returned in the order that they are emitted, and are
+    /// paired with the address of the contract that emitted it.
+    pub fn events(&self) -> impl Iterator<Item = (ContractAddress, &[ContractEvent])> {
+        self.trace_elements.iter().flat_map(|cte| {
+            if let ContractTraceElement::Updated { data } = cte {
+                Some((data.address, data.events.as_slice()))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Extract the transfers **to accounts** that occurred during
+    /// invocation. The return value is an iterator over triples `(from, amount,
+    /// to)` where `from` is the sender contract, and `to` is the receiver
+    /// account. The transfers are returned in the order that they occurred.
+    pub fn account_transfers(
+        &self,
+    ) -> impl Iterator<Item = (ContractAddress, Amount, AccountAddress)> + '_ {
+        self.trace_elements.iter().flat_map(|cte| {
+            if let ContractTraceElement::Transferred { from, amount, to } = cte {
+                Some((*from, *amount, *to))
+            } else {
+                None
+            }
+        })
+    }
 }
 
 /// An error that occured during a [`Chain::contract_update`] or


### PR DESCRIPTION
## Purpose

Remove the "logs/events" since last interrupt. That semantics is awkward and I don't think it brings much value.

The entire log can be recovered from the trace_elements.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.