### PR TITLE
Bump version of cargo-concordium to 2.7.1

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
+## 2.7.1
+
 - Support calling `cargo concordium build` and `cargo concordium test` from a project subdirectory.
+- Fix a bug in schema parsing in `cargo concordium run` commands. Schemas with
+  negative integers did not allow for supplying negative integers.
 
 ## 2.7.0
 

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-concordium"
-version = "2.7.0"
+version = "2.7.1"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-concordium"
-version = "2.7.0"
+version = "2.7.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license-file = "../LICENSE"


### PR DESCRIPTION
## Purpose

Bump version to 2.7.1 for release.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
