### PR TITLE
cargo-concordium: Create directory path for produced artifacts

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Non-existing directories in paths provided to the following arguments for when running `cargo concordium build` will now be created instead of causing an error: --out`, `--schema-out`, `--schema-json-out`, `--schema-base64-out`.
+
 ## 2.7.1
 
 - Support calling `cargo concordium build` and `cargo concordium test` from a project subdirectory.

--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-- Non-existing directories in paths provided to the following arguments for when running `cargo concordium build` will now be created instead of causing an error: --out`, `--schema-out`, `--schema-json-out`, `--schema-base64-out`.
+- Non-existing directories in paths provided to the following arguments for when running `cargo concordium build` will now be created instead of causing an error: `--out`, `--schema-out`, `--schema-json-out`, `--schema-base64-out`.
+  Likewise for the `--out-bin` and `--out-json` arguments provided to `cargo concordium run init` and `cargo concordium run update`.
 
 ## 2.7.1
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -216,6 +216,10 @@ pub fn build_contract(
     };
 
     let total_module_len = output_bytes.len();
+    if let Some(out_dir) = out_filename.parent() {
+        fs::create_dir_all(out_dir)
+            .context("Unable to create directory for the resulting smart contract module")?;
+    }
     fs::write(out_filename, output_bytes)?;
     Ok((total_module_len, return_schema))
 }
@@ -431,6 +435,10 @@ fn write_schema_json(
         contract_name,
         out_path.display()
     );
+    if let Some(out_dir) = out_path.parent() {
+        fs::create_dir_all(out_dir)
+            .context("Unable to create directory for the resulting JSON schemas")?;
+    }
     std::fs::write(out_path, serde_json::to_string_pretty(&schema_json)?)
         .context("Unable to write schema output.")?;
     Ok(())
@@ -448,7 +456,10 @@ pub fn write_schema_base64(
         // writing base64 schema to file
         Some(out) => {
             println!("   Writing base64 schema to {}.", out.display());
-
+            if let Some(out_dir) = out.parent() {
+                fs::create_dir_all(out_dir)
+                    .context("Unable to create directory for the resulting base64 schema")?;
+            }
             // save the schema base64 representation to the file
             std::fs::write(out, schema_base64).context("Unable to write schema output.")?;
         }

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -118,7 +118,7 @@ pub fn build_contract(
 
     let package = metadata
         .root_package()
-        .context("Unable to determine package")?;
+        .context("Unable to determine package.")?;
 
     let target_dir = format!("{}/concordium", metadata.target_directory);
 
@@ -218,7 +218,7 @@ pub fn build_contract(
     let total_module_len = output_bytes.len();
     if let Some(out_dir) = out_filename.parent() {
         fs::create_dir_all(out_dir)
-            .context("Unable to create directory for the resulting smart contract module")?;
+            .context("Unable to create directory for the resulting smart contract module.")?;
     }
     fs::write(out_filename, output_bytes)?;
     Ok((total_module_len, return_schema))
@@ -330,7 +330,7 @@ pub fn build_contract_schema<A>(
 
     let package = metadata
         .root_package()
-        .context("Unable to determine package")?;
+        .context("Unable to determine package.")?;
 
     let target_dir = format!("{}/concordium", metadata.target_directory);
 
@@ -437,7 +437,7 @@ fn write_schema_json(
     );
     if let Some(out_dir) = out_path.parent() {
         fs::create_dir_all(out_dir)
-            .context("Unable to create directory for the resulting JSON schemas")?;
+            .context("Unable to create directory for the resulting JSON schemas.")?;
     }
     std::fs::write(out_path, serde_json::to_string_pretty(&schema_json)?)
         .context("Unable to write schema output.")?;
@@ -458,7 +458,7 @@ pub fn write_schema_base64(
             println!("   Writing base64 schema to {}.", out.display());
             if let Some(out_dir) = out.parent() {
                 fs::create_dir_all(out_dir)
-                    .context("Unable to create directory for the resulting base64 schema")?;
+                    .context("Unable to create directory for the resulting base64 schema.")?;
             }
             // save the schema base64 representation to the file
             std::fs::write(out, schema_base64).context("Unable to write schema output.")?;
@@ -679,7 +679,7 @@ pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyh
 
     let package = metadata
         .root_package()
-        .context("Unable to determine package")?;
+        .context("Unable to determine package.")?;
 
     let target_dir = format!("{}/concordium", metadata.target_directory);
 

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -558,6 +558,10 @@ pub fn main() -> anyhow::Result<()> {
                         );
                     }
 
+                    if let Some(out_dir) = schema_out.parent() {
+                        fs::create_dir_all(out_dir)
+                            .context("Unable to create directory for the resulting schema")?;
+                    }
                     fs::write(schema_out, &module_schema_bytes)
                         .context("Could not write schema file.")?;
                 }

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -841,6 +841,11 @@ fn handle_run_v0(run_cmd: RunCommand, module: &[u8]) -> anyhow::Result<()> {
         };
 
         if let Some(file_path) = &runner.out_bin {
+            if let Some(out_dir) = file_path.parent() {
+                fs::create_dir_all(out_dir)
+                    .context("Unable to create directory for the binary state output")?;
+            }
+
             fs::write(file_path, &state).context("Could not write state to file")?;
         }
         if let Some(file_path) = &runner.out_json {
@@ -855,6 +860,10 @@ fn handle_run_v0(run_cmd: RunCommand, module: &[u8]) -> anyhow::Result<()> {
             let json_string = schema_state
                 .to_json_string_pretty(state)
                 .map_err(|_| anyhow::anyhow!("Could not output contract state in JSON."))?;
+            if let Some(out_dir) = file_path.parent() {
+                fs::create_dir_all(out_dir)
+                    .context("Unable to create directory for the JSON state output")?;
+            }
             fs::write(file_path, json_string).context("Could not write out the state.")?;
         }
         Ok(())

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -560,17 +560,12 @@ pub fn main() -> anyhow::Result<()> {
 
                     if let Some(out_dir) = schema_out.parent() {
                         fs::create_dir_all(out_dir)
-                            .context("Unable to create directory for the resulting schema")?;
+                            .context("Unable to create directory for the resulting schema.")?;
                     }
                     fs::write(schema_out, &module_schema_bytes)
                         .context("Could not write schema file.")?;
                 }
                 if let Some(schema_json_out) = schema_json_out {
-                    ensure!(
-                        schema_json_out.is_dir(),
-                        "The `--schema-json-out` flag should point to an existing directory \
-                         (expected input `./my/path/`)."
-                    );
                     write_json_schema(&schema_json_out, module_schema)
                         .context("Could not write JSON schema files.")?;
                 }
@@ -843,10 +838,10 @@ fn handle_run_v0(run_cmd: RunCommand, module: &[u8]) -> anyhow::Result<()> {
         if let Some(file_path) = &runner.out_bin {
             if let Some(out_dir) = file_path.parent() {
                 fs::create_dir_all(out_dir)
-                    .context("Unable to create directory for the binary state output")?;
+                    .context("Unable to create directory for the binary state output.")?;
             }
 
-            fs::write(file_path, &state).context("Could not write state to file")?;
+            fs::write(file_path, &state).context("Could not write state to file.")?;
         }
         if let Some(file_path) = &runner.out_json {
             contract_schema_opt.context(
@@ -862,7 +857,7 @@ fn handle_run_v0(run_cmd: RunCommand, module: &[u8]) -> anyhow::Result<()> {
                 .map_err(|_| anyhow::anyhow!("Could not output contract state in JSON."))?;
             if let Some(out_dir) = file_path.parent() {
                 fs::create_dir_all(out_dir)
-                    .context("Unable to create directory for the JSON state output")?;
+                    .context("Unable to create directory for the JSON state output.")?;
             }
             fs::write(file_path, json_string).context("Could not write out the state.")?;
         }


### PR DESCRIPTION
## Purpose/Changes

`cargo-concordium` now creates non-existing directories for out paths instead of producing an error.
This is relevant for:

**`cargo concordium build`, when providing:**

- `--out path`
- `--schema-out path`
- `--schema-json-out path`
- `--schema-base64-out path`

**`cargo concordium run update` and `cargo concordium run init` when providing:**
- `--out-bin path`
- `--out-json path`


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
