### PR TITLE
Fix building smart contracts in workspace projects

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Non-existing directories in paths provided to the following arguments for when running `cargo concordium build` will now be created instead of causing an error: `--out`, `--schema-out`, `--schema-json-out`, `--schema-base64-out`.
   Likewise for the `--out-bin` and `--out-json` arguments provided to `cargo concordium run init` and `cargo concordium run update`.
+- Fix a bug where `cargo concordium` was unable to determine the smart contract package if the package was part of a Cargo workspace.
 
 ## 2.7.1
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -112,7 +112,6 @@ pub fn build_contract(
     };
 
     let metadata = MetadataCommand::new()
-        .no_deps()
         .exec()
         .context("Could not access cargo metadata.")?;
 
@@ -324,7 +323,6 @@ pub fn build_contract_schema<A>(
     generate_schema: impl FnOnce(&[u8]) -> ExecResult<A>,
 ) -> anyhow::Result<A> {
     let metadata = MetadataCommand::new()
-        .no_deps()
         .exec()
         .context("Could not access cargo metadata.")?;
 
@@ -673,7 +671,6 @@ pub fn write_json_schema_to_file_v3(
 /// number generator. If `None` is given, a random seed will be sampled.
 pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyhow::Result<bool> {
     let metadata = MetadataCommand::new()
-        .no_deps()
         .exec()
         .context("Could not access cargo metadata.")?;
 


### PR DESCRIPTION
## Purpose

Reading cargo metadata fails when the smart contract is part of a workspace. This is due to how `cargo_metadata` works when using `no_deps`. See the link below for more information.

https://github.com/oli-obk/cargo_metadata/issues/198

## Changes

Removing the calls to `.no_deps()`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
