### PR TITLE
Prepare for release of cargo-concordium

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 2.8.0
 
 - Non-existing directories in paths provided to the following arguments for when running `cargo concordium build` will now be created instead of causing an error: `--out`, `--schema-out`, `--schema-json-out`, `--schema-base64-out`.
   Likewise for the `--out-bin` and `--out-json` arguments provided to `cargo concordium run init` and `cargo concordium run update`.

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-concordium"
-version = "2.7.1"
+version = "2.8.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-concordium"
-version = "2.7.1"
+version = "2.8.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license-file = "../LICENSE"


### PR DESCRIPTION
## Purpose

Prepare for release of `cargo-concordium` version `2.8.0`

