### PR TITLE
Make vscode init project ensure cargo-generate is installed

### DIFF
--- a/vscode-smart-contracts/src/extension.ts
+++ b/vscode-smart-contracts/src/extension.ts
@@ -25,27 +25,27 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "concordium-smart-contracts.version",
-      Commands.version
+      Commands.displayErrorWrapper(Commands.version)
     ),
     vscode.commands.registerTextEditorCommand(
       "concordium-smart-contracts.build",
-      Commands.build
+      Commands.displayErrorWrapper(Commands.build)
     ),
     vscode.commands.registerTextEditorCommand(
       "concordium-smart-contracts.build-skip-schema",
-      Commands.buildSkipSchema
+      Commands.displayErrorWrapper(Commands.buildSkipSchema)
     ),
     vscode.commands.registerTextEditorCommand(
       "concordium-smart-contracts.build-embed-schema",
-      Commands.buildEmbedSchema
+      Commands.displayErrorWrapper(Commands.buildEmbedSchema)
     ),
     vscode.commands.registerTextEditorCommand(
       "concordium-smart-contracts.test",
-      Commands.test
+      Commands.displayErrorWrapper(Commands.test)
     ),
     vscode.commands.registerCommand(
       "concordium-smart-contracts.init-project",
-      Commands.initProject
+      Commands.displayErrorWrapper(Commands.initProject)
     ),
     vscode.tasks.registerTaskProvider(CONCORDIUM_TASK_TYPE, taskProvider)
   );


### PR DESCRIPTION
## Purpose

Make vscode init project ensure cargo-generate is installed.

Also, fixes an issue where it would install it in the case of the prompt timeout.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.


