### PR TITLE
Include trace elements for failures

### DIFF
--- a/concordium-smart-contract-testing/CHANGELOG.md
+++ b/concordium-smart-contract-testing/CHANGELOG.md
@@ -5,12 +5,12 @@
 - Include `ContractTraceElement`s for failed contract executions, including internal failures.
   - Introduce the enum `DebugTraceElement`, which has information about trace elements, including failed ones and the cause of error, and the energy usage.
   - On the `ContractInvokeSuccess` type:
-    - Change the type of the `trace_elements` to be `Vec<DebugTraceElement>` instead of `Vec<ContractTraceElement>`. (breaking change)
+    - Change the type of the `trace_elements` field to be `Vec<DebugTraceElement>` instead of `Vec<ContractTraceElement>`. (breaking change)
     - Add a helper method, `effective_trace_elements()`, to retrieve the "effective" trace elements, i.e., elements that were *not* rolled back.
       - These are the elements that were previously returned in the `trace_elements` field.
-    - To migrate existing code, replace `some_update.trace_elements` with `some_update.effective_trace_elements().collect::<Vec<_>>()`, 
-      and dereference elements of the list if necessary.
-    - Add a helper method, `rollbacks_occurred()`, to determine whether any internal failures occurred. 
+      - There is also a version of the method which clones: `effective_trace_elements_cloned()`.
+    - To migrate existing code, replace `some_update.trace_elements()` with `some_update.effective_trace_elements_cloned()`.
+    - Add a helper method, `rollbacks_occurred()`, to determine whether any internal failures or rollbacks occurred. 
   - On the `ContractInvokeError` type:
     - Include the field `trace_elements` of type `Vec<DebugTraceElements>` with the trace elements that were hitherto discarded. (breaking change)
     - To migrate, include the new field or use `..` when pattern matching on the type.

--- a/concordium-smart-contract-testing/CHANGELOG.md
+++ b/concordium-smart-contract-testing/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## Unreleased
+
+- Include `ContractTraceElement`s for failed contract executions, including internal failures.
+  - Introduce the enum `DebugTraceElement`, which has information about trace elements, including failed ones and the cause of error, and the energy usage.
+  - On the `ContractInvokeSuccess` type:
+    - Change the type of the `trace_elements` to be `Vec<DebugTraceElement>` instead of `Vec<ContractTraceElement>`. (breaking change)
+    - Add a helper method, `effective_trace_elements()`, to retrieve the "effective" trace elements, i.e., elements that were *not* rolled back.
+      - These are the elements that were previously returned in the `trace_elements` field.
+    - To migrate existing code, replace `some_update.trace_elements` with `some_update.effective_trace_elements().collect::<Vec<_>>()`, 
+      and dereference elements of the list if necessary.
+    - Add a helper method, `rollbacks_occurred()`, to determine whether any internal failures occurred. 
+  - On the `ContractInvokeError` type:
+    - Include the field `trace_elements` of type `Vec<DebugTraceElements>` with the trace elements that were hitherto discarded. (breaking change)
+    - To migrate, include the new field or use `..` when pattern matching on the type.
+
 ## 1.0.0
 
 - The initial release of the library.

--- a/concordium-smart-contract-testing/CHANGELOG.md
+++ b/concordium-smart-contract-testing/CHANGELOG.md
@@ -9,7 +9,7 @@
     - Add a helper method, `effective_trace_elements()`, to retrieve the "effective" trace elements, i.e., elements that were *not* rolled back.
       - These are the elements that were previously returned in the `trace_elements` field.
       - There is also a version of the method which clones: `effective_trace_elements_cloned()`.
-    - To migrate existing code, replace `some_update.trace_elements()` with `some_update.effective_trace_elements_cloned()`.
+    - To migrate existing code, replace `some_update.trace_elements` with `some_update.effective_trace_elements_cloned()`.
     - Add a helper method, `rollbacks_occurred()`, to determine whether any internal failures or rollbacks occurred. 
   - On the `ContractInvokeError` type:
     - Include the field `trace_elements` of type `Vec<DebugTraceElements>` with the trace elements that were hitherto discarded. (breaking change)

--- a/concordium-smart-contract-testing/src/impls.rs
+++ b/concordium-smart-contract-testing/src/impls.rs
@@ -751,7 +751,7 @@ impl Chain {
                     );
                     res.map_err(|_| self.invocation_out_of_energy_error(energy_reserved))?
                 } else {
-                    // An error occured, so state hasn't changed.
+                    // An error occurred, so state hasn't changed.
                     false
                 };
                 self.contract_invocation_process_response(
@@ -853,7 +853,7 @@ impl Chain {
                         .collect_energy_for_state(&mut remaining_energy, contract_address)
                         .map_err(|_| self.invocation_out_of_energy_error(energy_reserved))?
                 } else {
-                    // An error occured, so state hasn't changed.
+                    // An error occurred, so state hasn't changed.
                     false
                 };
                 self.contract_invocation_process_response(

--- a/concordium-smart-contract-testing/src/invocation/types.rs
+++ b/concordium-smart-contract-testing/src/invocation/types.rs
@@ -28,7 +28,15 @@ pub(crate) struct EntrypointInvocationHandler<'a, 'b> {
     pub(crate) changeset: ChangeSet,
     /// The energy remaining for execution.
     pub(crate) remaining_energy: &'a mut Energy,
+    /// The energy reserved for the execution. Used for calculating intermediate
+    /// energy usages in contract trace elements.
+    pub(crate) energy_reserved: Energy,
+    /// An immutable reference to the chain, used for looking up information,
+    /// including contracts, modules, and accounts.
     pub(crate) chain: &'b Chain,
+    /// The next contract modification index to be given out.
+    /// The index is global per transaction, which is why this field is
+    /// needed.
     pub(crate) next_contract_modification_index: u32,
 }
 

--- a/concordium-smart-contract-testing/src/lib.rs
+++ b/concordium-smart-contract-testing/src/lib.rs
@@ -70,7 +70,7 @@
 //!     .unwrap();
 //!
 //! // Check the trace elements produced (updates, interrupts, resumes, transfers, etc.).
-//! assert!(matches!(update.success_trace_elements().collect::<Vec<_>>()[..], [ContractTraceElement::Updated{..}]));
+//! assert!(matches!(update.effective_trace_elements().collect::<Vec<_>>()[..], [ContractTraceElement::Updated{..}]));
 //!
 //! // Check the return value.
 //! assert_eq!(update.return_value, to_bytes(&84u8));

--- a/concordium-smart-contract-testing/src/lib.rs
+++ b/concordium-smart-contract-testing/src/lib.rs
@@ -70,7 +70,7 @@
 //!     .unwrap();
 //!
 //! // Check the trace elements produced (updates, interrupts, resumes, transfers, etc.).
-//! assert!(matches!(update.trace_elements[..], [ContractTraceElement::Updated{..}]));
+//! assert!(matches!(update.success_trace_elements().collect::<Vec<_>>()[..], [ContractTraceElement::Updated{..}]));
 //!
 //! // Check the return value.
 //! assert_eq!(update.return_value, to_bytes(&84u8));

--- a/concordium-smart-contract-testing/src/types.rs
+++ b/concordium-smart-contract-testing/src/types.rs
@@ -324,16 +324,37 @@ impl ContractInvokeSuccess {
         })
     }
 
-    /// Get an iterator over all the [`ContractTraceElement`]s that have *not*
-    /// been rolled back.
+    /// Get an iterator over references of all the [`ContractTraceElement`]s
+    /// that have *not* been rolled back.
     ///
     /// The trace elements returned here corresponds to the ones returned by the
     /// node.
+    ///
+    /// See also [`Self::effective_trace_elements_cloned`] for a version with
+    /// clones.
     pub fn effective_trace_elements(&self) -> impl Iterator<Item = &ContractTraceElement> {
         self.trace_elements.iter().filter_map(|cte| match cte {
             DebugTraceElement::Regular { trace_element, .. } => Some(trace_element),
             DebugTraceElement::WithFailures { .. } => None,
         })
+    }
+
+    /// Get an iterator over clones of all the [`ContractTraceElement`]s that
+    /// have *not* been rolled back.
+    ///
+    /// The trace elements returned here corresponds to the ones returned by the
+    /// node.
+    ///
+    /// See also [`Self::effective_trace_elements`] for a version with
+    /// references.
+    pub fn effective_trace_elements_cloned(&self) -> Vec<ContractTraceElement> {
+        self.trace_elements
+            .iter()
+            .filter_map(|cte| match cte {
+                DebugTraceElement::Regular { trace_element, .. } => Some(trace_element.clone()),
+                DebugTraceElement::WithFailures { .. } => None,
+            })
+            .collect()
     }
 
     /// Get the successful trace elements grouped by which contract they

--- a/concordium-smart-contract-testing/tests/checkpointing.rs
+++ b/concordium-smart-contract-testing/tests/checkpointing.rs
@@ -96,6 +96,9 @@ fn test_case_1() {
         )
         .expect("Updating contract should succeed");
 
+    // Check that rollbacks occurred.
+    assert!(update.rollbacks_occurred());
+
     // Check that all the trace elements are as expected, including the ones
     // resulting in a failure. Some imports to simplify the names in the assert.
     use ContractTraceElement::*;
@@ -227,6 +230,9 @@ fn test_case_2() {
     assert_eq!(update_a_modify_proxy.address, res_init_a.contract_address);
     assert_eq!(update_a_modify_proxy.receive_name, "a.a_modify_proxy");
     assert!(updates.next().is_none(), "No more updates expected.");
+
+    // Check that no rollbacks occurred.
+    assert!(!trace.rollbacks_occurred());
 }
 
 /// This test has the following call pattern:
@@ -370,7 +376,7 @@ fn test_case_4() {
         Amount::zero(),
     );
 
-    chain
+    let update = chain
         .contract_update(
             Signer::with_one_key(),
             ACC_0,
@@ -389,4 +395,7 @@ fn test_case_4() {
             },
         )
         .expect("Updating contract should succeed");
+
+    // Check that no rollbacks occurred.
+    assert!(!update.rollbacks_occurred());
 }

--- a/concordium-smart-contract-testing/tests/checkpointing.rs
+++ b/concordium-smart-contract-testing/tests/checkpointing.rs
@@ -78,7 +78,7 @@ fn test_case_1() {
         Amount::zero(),
     );
 
-    chain
+    let update = chain
         .contract_update(
             Signer::with_one_key(),
             ACC_0,
@@ -95,6 +95,31 @@ fn test_case_1() {
             },
         )
         .expect("Updating contract should succeed");
+
+    // Check that all the trace elements are as expected, including the ones
+    // resulting in a failure. Some imports to simplify the names in the assert.
+    use ContractTraceElement::*;
+    use DebugTraceElement::*;
+    use InvokeExecutionError::*;
+    assert!(matches!(&update.trace_elements[..], [
+        Regular {
+            trace_element: Interrupted { .. },
+            ..
+        },
+        WithFailures {
+            error: Trap { .. },
+            trace_elements,
+            ..
+        },
+        Regular {
+            trace_element: Resumed { .. },
+            ..
+        },
+        Regular {
+            trace_element: Updated { .. },
+            ..
+        }
+    ] if matches!(trace_elements[..], [Regular { trace_element: Interrupted {..}, ..}, Regular { trace_element: Updated {..}, .. }, Regular { trace_element: Resumed {..}, .. }])));
 }
 
 /// This test has the following call pattern:

--- a/concordium-smart-contract-testing/tests/queries.rs
+++ b/concordium-smart-contract-testing/tests/queries.rs
@@ -75,9 +75,10 @@ mod query_account_balance {
                     - res_update.transaction_fee
             )
         );
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [ContractTraceElement::Updated { .. }]
+        ));
     }
 
     /// Queries the balance of the invoker account, which will have have the
@@ -148,9 +149,10 @@ mod query_account_balance {
             // for the NRG use. Not the reserved amount.
             Some(initial_balance - res_update.transaction_fee - update_amount)
         );
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [ContractTraceElement::Updated { .. }]
+        ));
     }
 
     /// Makes a transfer to an account, then queries its balance and asserts
@@ -230,12 +232,15 @@ mod query_account_balance {
             chain.account_balance_available(ACC_1),
             Some(initial_balance + amount_to_send)
         );
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Interrupted { .. },
-            ContractTraceElement::Transferred { .. },
-            ContractTraceElement::Resumed { .. },
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [
+                ContractTraceElement::Interrupted { .. },
+                ContractTraceElement::Transferred { .. },
+                ContractTraceElement::Resumed { .. },
+                ContractTraceElement::Updated { .. }
+            ]
+        ));
     }
 
     #[test]
@@ -297,9 +302,10 @@ mod query_account_balance {
                     - res_update.transaction_fee
             )
         );
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [ContractTraceElement::Updated { .. }]
+        ));
     }
 
     /// Queries the balance of a missing account and asserts that it returns
@@ -364,9 +370,10 @@ mod query_account_balance {
                     - res_update.transaction_fee
             )
         );
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [ContractTraceElement::Updated { .. }]
+        ));
     }
 }
 
@@ -442,9 +449,10 @@ mod query_contract_balance {
             )
             .expect("Updating valid contract should work");
 
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [ContractTraceElement::Updated { .. }]
+        ));
     }
 
     /// Test querying the balance of the contract instance itself. This
@@ -503,9 +511,10 @@ mod query_contract_balance {
             )
             .expect("Updating valid contract should work");
 
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [ContractTraceElement::Updated { .. }]
+        ));
     }
 
     /// Test querying the balance after a transfer of CCD.
@@ -568,12 +577,15 @@ mod query_contract_balance {
             )
             .expect("Updating valid contract should work");
 
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Interrupted { .. },
-            ContractTraceElement::Transferred { .. },
-            ContractTraceElement::Resumed { .. },
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [
+                ContractTraceElement::Interrupted { .. },
+                ContractTraceElement::Transferred { .. },
+                ContractTraceElement::Resumed { .. },
+                ContractTraceElement::Updated { .. }
+            ]
+        ));
     }
 
     /// Test querying the balance of a contract that doesn't exist.
@@ -628,9 +640,10 @@ mod query_contract_balance {
             )
             .expect("Updating valid contract should work");
 
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [ContractTraceElement::Updated { .. }]
+        ));
     }
 }
 
@@ -687,8 +700,9 @@ mod query_exchange_rates {
             )
             .expect("Updating valid contract should work");
 
-        assert!(matches!(res_update.trace_elements[..], [
-            ContractTraceElement::Updated { .. }
-        ]));
+        assert!(matches!(
+            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            [ContractTraceElement::Updated { .. }]
+        ));
     }
 }

--- a/concordium-smart-contract-testing/tests/queries.rs
+++ b/concordium-smart-contract-testing/tests/queries.rs
@@ -76,7 +76,7 @@ mod query_account_balance {
             )
         );
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -150,7 +150,7 @@ mod query_account_balance {
             Some(initial_balance - res_update.transaction_fee - update_amount)
         );
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -233,7 +233,7 @@ mod query_account_balance {
             Some(initial_balance + amount_to_send)
         );
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [
                 ContractTraceElement::Interrupted { .. },
                 ContractTraceElement::Transferred { .. },
@@ -303,7 +303,7 @@ mod query_account_balance {
             )
         );
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -371,7 +371,7 @@ mod query_account_balance {
             )
         );
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -450,7 +450,7 @@ mod query_contract_balance {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -512,7 +512,7 @@ mod query_contract_balance {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -578,7 +578,7 @@ mod query_contract_balance {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [
                 ContractTraceElement::Interrupted { .. },
                 ContractTraceElement::Transferred { .. },
@@ -641,7 +641,7 @@ mod query_contract_balance {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -701,7 +701,7 @@ mod query_exchange_rates {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.success_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }

--- a/concordium-smart-contract-testing/tests/queries.rs
+++ b/concordium-smart-contract-testing/tests/queries.rs
@@ -76,7 +76,7 @@ mod query_account_balance {
             )
         );
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -150,7 +150,7 @@ mod query_account_balance {
             Some(initial_balance - res_update.transaction_fee - update_amount)
         );
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -233,7 +233,7 @@ mod query_account_balance {
             Some(initial_balance + amount_to_send)
         );
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [
                 ContractTraceElement::Interrupted { .. },
                 ContractTraceElement::Transferred { .. },
@@ -303,7 +303,7 @@ mod query_account_balance {
             )
         );
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -371,7 +371,7 @@ mod query_account_balance {
             )
         );
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -450,7 +450,7 @@ mod query_contract_balance {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -512,7 +512,7 @@ mod query_contract_balance {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -578,7 +578,7 @@ mod query_contract_balance {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [
                 ContractTraceElement::Interrupted { .. },
                 ContractTraceElement::Transferred { .. },
@@ -641,7 +641,7 @@ mod query_contract_balance {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }
@@ -701,7 +701,7 @@ mod query_exchange_rates {
             .expect("Updating valid contract should work");
 
         assert!(matches!(
-            res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+            res_update.effective_trace_elements_cloned()[..],
             [ContractTraceElement::Updated { .. }]
         ));
     }

--- a/concordium-smart-contract-testing/tests/transfer.rs
+++ b/concordium-smart-contract-testing/tests/transfer.rs
@@ -96,30 +96,33 @@ fn test_transfer() {
         Amount::from_micro_ccd(1000 - 17),
         chain.get_contract(contract_address).unwrap().self_balance
     );
-    assert_eq!(res_update.trace_elements[..], [
-        ContractTraceElement::Interrupted {
-            address: contract_address,
-            events:  Vec::new(),
-        },
-        ContractTraceElement::Transferred {
-            from:   contract_address,
-            amount: Amount::from_micro_ccd(17),
-            to:     ACC_0,
-        },
-        ContractTraceElement::Resumed {
-            address: contract_address,
-            success: true,
-        },
-        ContractTraceElement::Updated {
-            data: InstanceUpdatedEvent {
-                address:          contract_address,
-                amount:           Amount::zero(),
-                receive_name:     OwnedReceiveName::new_unchecked("transfer.send".into()),
-                contract_version: concordium_base::smart_contracts::WasmVersion::V1,
-                instigator:       Address::Account(ACC_0),
-                message:          parameter,
-                events:           Vec::new(),
+    assert_eq!(
+        res_update.success_trace_elements().collect::<Vec<_>>()[..],
+        [
+            &ContractTraceElement::Interrupted {
+                address: contract_address,
+                events:  Vec::new(),
             },
-        }
-    ])
+            &ContractTraceElement::Transferred {
+                from:   contract_address,
+                amount: Amount::from_micro_ccd(17),
+                to:     ACC_0,
+            },
+            &ContractTraceElement::Resumed {
+                address: contract_address,
+                success: true,
+            },
+            &ContractTraceElement::Updated {
+                data: InstanceUpdatedEvent {
+                    address:          contract_address,
+                    amount:           Amount::zero(),
+                    receive_name:     OwnedReceiveName::new_unchecked("transfer.send".into()),
+                    contract_version: concordium_base::smart_contracts::WasmVersion::V1,
+                    instigator:       Address::Account(ACC_0),
+                    message:          parameter,
+                    events:           Vec::new(),
+                },
+            }
+        ]
+    )
 }

--- a/concordium-smart-contract-testing/tests/transfer.rs
+++ b/concordium-smart-contract-testing/tests/transfer.rs
@@ -97,7 +97,7 @@ fn test_transfer() {
         chain.get_contract(contract_address).unwrap().self_balance
     );
     assert_eq!(
-        res_update.success_trace_elements().collect::<Vec<_>>()[..],
+        res_update.effective_trace_elements().collect::<Vec<_>>()[..],
         [
             &ContractTraceElement::Interrupted {
                 address: contract_address,

--- a/concordium-smart-contract-testing/tests/transfer.rs
+++ b/concordium-smart-contract-testing/tests/transfer.rs
@@ -96,33 +96,30 @@ fn test_transfer() {
         Amount::from_micro_ccd(1000 - 17),
         chain.get_contract(contract_address).unwrap().self_balance
     );
-    assert_eq!(
-        res_update.effective_trace_elements().collect::<Vec<_>>()[..],
-        [
-            &ContractTraceElement::Interrupted {
-                address: contract_address,
-                events:  Vec::new(),
+    assert_eq!(res_update.effective_trace_elements_cloned()[..], [
+        ContractTraceElement::Interrupted {
+            address: contract_address,
+            events:  Vec::new(),
+        },
+        ContractTraceElement::Transferred {
+            from:   contract_address,
+            amount: Amount::from_micro_ccd(17),
+            to:     ACC_0,
+        },
+        ContractTraceElement::Resumed {
+            address: contract_address,
+            success: true,
+        },
+        ContractTraceElement::Updated {
+            data: InstanceUpdatedEvent {
+                address:          contract_address,
+                amount:           Amount::zero(),
+                receive_name:     OwnedReceiveName::new_unchecked("transfer.send".into()),
+                contract_version: concordium_base::smart_contracts::WasmVersion::V1,
+                instigator:       Address::Account(ACC_0),
+                message:          parameter,
+                events:           Vec::new(),
             },
-            &ContractTraceElement::Transferred {
-                from:   contract_address,
-                amount: Amount::from_micro_ccd(17),
-                to:     ACC_0,
-            },
-            &ContractTraceElement::Resumed {
-                address: contract_address,
-                success: true,
-            },
-            &ContractTraceElement::Updated {
-                data: InstanceUpdatedEvent {
-                    address:          contract_address,
-                    amount:           Amount::zero(),
-                    receive_name:     OwnedReceiveName::new_unchecked("transfer.send".into()),
-                    contract_version: concordium_base::smart_contracts::WasmVersion::V1,
-                    instigator:       Address::Account(ACC_0),
-                    message:          parameter,
-                    events:           Vec::new(),
-                },
-            }
-        ]
-    )
+        }
+    ])
 }

--- a/concordium-smart-contract-testing/tests/upgrades.rs
+++ b/concordium-smart-contract-testing/tests/upgrades.rs
@@ -84,15 +84,15 @@ fn test() {
         .expect("Updating the `newfun` from the `upgrading_1` module should work");
 
     assert!(
-        matches!(res_update_upgrade.effective_trace_elements().collect::<Vec<_>>()[..], [
+        matches!(res_update_upgrade.effective_trace_elements_cloned()[..], [
                 ContractTraceElement::Interrupted { .. },
                 ContractTraceElement::Upgraded { from, to, .. },
                 ContractTraceElement::Resumed { .. },
                 ContractTraceElement::Updated { .. },
-            ] if *from == res_deploy_0.module_reference && *to == res_deploy_1.module_reference)
+            ] if from == res_deploy_0.module_reference && to == res_deploy_1.module_reference)
     );
     assert!(matches!(
-        res_update_new.effective_trace_elements().collect::<Vec<_>>()[..],
+        res_update_new.effective_trace_elements_cloned()[..],
         [ContractTraceElement::Updated { .. }]
     ));
 }
@@ -154,7 +154,7 @@ fn test_self_invoke() {
         .expect("Updating valid contract should work");
 
     assert!(matches!(
-        res_update.effective_trace_elements().collect::<Vec<_>>()[..],
+        res_update.effective_trace_elements_cloned()[..],
         [
             // Invoking `contract.name`
             ContractTraceElement::Interrupted { .. },
@@ -224,14 +224,12 @@ fn test_missing_module() {
         )
         .expect("Updating valid contract should work");
 
-    assert!(
-        matches!(res_update.effective_trace_elements().collect::<Vec<_>>()[..], [
+    assert!(matches!(res_update.effective_trace_elements_cloned()[..], [
                 ContractTraceElement::Interrupted { .. },
                 // No upgrade event, as it is supposed to fail.
                 ContractTraceElement::Resumed { success, .. },
                 ContractTraceElement::Updated { .. },
-            ] if !success )
-    );
+            ] if !success ));
 }
 
 /// Test upgrading to a module where there isn't a matching contract
@@ -298,14 +296,12 @@ fn test_missing_contract() {
         )
         .expect("Updating valid contract should work");
 
-    assert!(
-        matches!(res_update.effective_trace_elements().collect::<Vec<_>>()[..], [
+    assert!(matches!(res_update.effective_trace_elements_cloned()[..], [
                 ContractTraceElement::Interrupted { .. },
                 // No upgrade event, as it is supposed to fail.
                 ContractTraceElement::Resumed { success, .. },
                 ContractTraceElement::Updated { .. },
-            ] if !success )
-    );
+            ] if !success ));
 }
 
 /// Test upgrading twice in the same transaction. The effect of the
@@ -376,8 +372,7 @@ fn test_twice_in_one_transaction() {
         )
         .expect("Updating valid contract should work");
 
-    assert!(
-        matches!(res_update.effective_trace_elements().collect::<Vec<_>>()[..], [
+    assert!(matches!(res_update.effective_trace_elements_cloned()[..], [
                 // Invoke the contract itself to check the name entrypoint return value.
                 ContractTraceElement::Interrupted { .. },
                 ContractTraceElement::Updated { .. },
@@ -400,11 +395,10 @@ fn test_twice_in_one_transaction() {
                 ContractTraceElement::Resumed { .. },
                 // Final update event
                 ContractTraceElement::Updated { .. },
-            ] if *first_from == res_deploy_0.module_reference
-                && *first_to == res_deploy_1.module_reference
-                && *second_from == res_deploy_1.module_reference
-                && *second_to == res_deploy_2.module_reference)
-    );
+            ] if first_from == res_deploy_0.module_reference
+                && first_to == res_deploy_1.module_reference
+                && second_from == res_deploy_1.module_reference
+                && second_to == res_deploy_2.module_reference));
 }
 
 /// Test upgrading to a module where there isn't a matching contract
@@ -464,10 +458,7 @@ fn test_chained_contract() {
     // Ends with 4 extra events: 3 events for an upgrade and 1 event for succesful
     // update.
     assert_eq!(
-        res_update
-            .effective_trace_elements()
-            .collect::<Vec<_>>()
-            .len() as u32,
+        res_update.effective_trace_elements_cloned().len() as u32,
         6 * number_of_upgrades + 4
     )
 }
@@ -688,9 +679,7 @@ fn test_changing_entrypoint() {
         .expect("Updating new_feature on _new_ module should work");
 
     assert!(matches!(
-        res_update_old_feature_0
-            .effective_trace_elements()
-            .collect::<Vec<_>>()[..],
+        res_update_old_feature_0.effective_trace_elements_cloned()[..],
         [ContractTraceElement::Updated { .. }]
     ));
     assert!(matches!(
@@ -700,9 +689,7 @@ fn test_changing_entrypoint() {
         }
     ));
     assert!(matches!(
-        res_update_upgrade
-            .effective_trace_elements()
-            .collect::<Vec<_>>()[..],
+        res_update_upgrade.effective_trace_elements_cloned()[..],
         [
             ContractTraceElement::Interrupted { .. },
             ContractTraceElement::Upgraded { .. },
@@ -717,9 +704,7 @@ fn test_changing_entrypoint() {
         }
     ));
     assert!(matches!(
-        res_update_new_feature_1
-            .effective_trace_elements()
-            .collect::<Vec<_>>()[..],
+        res_update_new_feature_1.effective_trace_elements_cloned()[..],
         [ContractTraceElement::Updated { .. }]
     ));
 }

--- a/concordium-smart-contract-testing/tests/upgrades.rs
+++ b/concordium-smart-contract-testing/tests/upgrades.rs
@@ -84,7 +84,7 @@ fn test() {
         .expect("Updating the `newfun` from the `upgrading_1` module should work");
 
     assert!(
-        matches!(res_update_upgrade.success_trace_elements().collect::<Vec<_>>()[..], [
+        matches!(res_update_upgrade.effective_trace_elements().collect::<Vec<_>>()[..], [
                 ContractTraceElement::Interrupted { .. },
                 ContractTraceElement::Upgraded { from, to, .. },
                 ContractTraceElement::Resumed { .. },
@@ -92,7 +92,7 @@ fn test() {
             ] if *from == res_deploy_0.module_reference && *to == res_deploy_1.module_reference)
     );
     assert!(matches!(
-        res_update_new.success_trace_elements().collect::<Vec<_>>()[..],
+        res_update_new.effective_trace_elements().collect::<Vec<_>>()[..],
         [ContractTraceElement::Updated { .. }]
     ));
 }
@@ -154,7 +154,7 @@ fn test_self_invoke() {
         .expect("Updating valid contract should work");
 
     assert!(matches!(
-        res_update.success_trace_elements().collect::<Vec<_>>()[..],
+        res_update.effective_trace_elements().collect::<Vec<_>>()[..],
         [
             // Invoking `contract.name`
             ContractTraceElement::Interrupted { .. },
@@ -225,7 +225,7 @@ fn test_missing_module() {
         .expect("Updating valid contract should work");
 
     assert!(
-        matches!(res_update.success_trace_elements().collect::<Vec<_>>()[..], [
+        matches!(res_update.effective_trace_elements().collect::<Vec<_>>()[..], [
                 ContractTraceElement::Interrupted { .. },
                 // No upgrade event, as it is supposed to fail.
                 ContractTraceElement::Resumed { success, .. },
@@ -299,7 +299,7 @@ fn test_missing_contract() {
         .expect("Updating valid contract should work");
 
     assert!(
-        matches!(res_update.success_trace_elements().collect::<Vec<_>>()[..], [
+        matches!(res_update.effective_trace_elements().collect::<Vec<_>>()[..], [
                 ContractTraceElement::Interrupted { .. },
                 // No upgrade event, as it is supposed to fail.
                 ContractTraceElement::Resumed { success, .. },
@@ -377,7 +377,7 @@ fn test_twice_in_one_transaction() {
         .expect("Updating valid contract should work");
 
     assert!(
-        matches!(res_update.success_trace_elements().collect::<Vec<_>>()[..], [
+        matches!(res_update.effective_trace_elements().collect::<Vec<_>>()[..], [
                 // Invoke the contract itself to check the name entrypoint return value.
                 ContractTraceElement::Interrupted { .. },
                 ContractTraceElement::Updated { .. },
@@ -465,7 +465,7 @@ fn test_chained_contract() {
     // update.
     assert_eq!(
         res_update
-            .success_trace_elements()
+            .effective_trace_elements()
             .collect::<Vec<_>>()
             .len() as u32,
         6 * number_of_upgrades + 4
@@ -689,7 +689,7 @@ fn test_changing_entrypoint() {
 
     assert!(matches!(
         res_update_old_feature_0
-            .success_trace_elements()
+            .effective_trace_elements()
             .collect::<Vec<_>>()[..],
         [ContractTraceElement::Updated { .. }]
     ));
@@ -701,7 +701,7 @@ fn test_changing_entrypoint() {
     ));
     assert!(matches!(
         res_update_upgrade
-            .success_trace_elements()
+            .effective_trace_elements()
             .collect::<Vec<_>>()[..],
         [
             ContractTraceElement::Interrupted { .. },
@@ -718,7 +718,7 @@ fn test_changing_entrypoint() {
     ));
     assert!(matches!(
         res_update_new_feature_1
-            .success_trace_elements()
+            .effective_trace_elements()
             .collect::<Vec<_>>()[..],
         [ContractTraceElement::Updated { .. }]
     ));


### PR DESCRIPTION
## Purpose

Closes https://github.com/Concordium/concordium-smart-contract-tools/issues/73, see it for more details.

I would especially like feedback on:
 - What else we could include in the trace elements.
 - Names chosen (not really that satisfied)
 - Extra helper functions needed.

## Changes

- Introduce a `DebugTraceElement` enum which contains additional information for the traces, including trace elements for failures.
- Add a helper method to extract the successful trace elements (which match the ones available in the node)
- Add an error type for execution errors during invocation. This also fixes a leftover TODO about including the error.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.