### PR TITLE
Prepare vscode extension for release

### DIFF
--- a/.github/workflows/ci-extension.yaml
+++ b/.github/workflows/ci-extension.yaml
@@ -20,7 +20,7 @@ on:
 
 env:
   NODEJS_VERSION: 18.x
-  RUST_VERSION: 1.62
+  RUST_VERSION: 1.65
 
 jobs:
 

--- a/vscode-smart-contracts/CHANGELOG.md
+++ b/vscode-smart-contracts/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.0.2
+
 - Update icon of the extension to better support dark themes.
 - Show an error when unable to determine the project, when running build and test commands.
 ## 1.0.1

--- a/vscode-smart-contracts/CHANGELOG.md
+++ b/vscode-smart-contracts/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Update icon of the extension to better support dark themes.
 - Show an error when unable to determine the project, when running build and test commands.
+- Contains `cargo-concordium` version 2.8.1
 ## 1.0.1
 
 - Initial release

--- a/vscode-smart-contracts/README.md
+++ b/vscode-smart-contracts/README.md
@@ -53,6 +53,11 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+### 1.0.2
+
+- Update icon of the extension to better support dark themes.
+- Show an error when unable to determine the project, when running build and test commands.
+
 ### 1.0.1
 
 Initial release of the extension with `cargo-concordium` version 2.8.0.

--- a/vscode-smart-contracts/README.md
+++ b/vscode-smart-contracts/README.md
@@ -57,6 +57,7 @@ This extension contributes the following settings:
 
 - Update icon of the extension to better support dark themes.
 - Show an error when unable to determine the project, when running build and test commands.
+- Contains `cargo-concordium` version 2.8.1
 
 ### 1.0.1
 

--- a/vscode-smart-contracts/package-lock.json
+++ b/vscode-smart-contracts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "concordium-smart-contracts",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "concordium-smart-contracts",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "glob": "^8.1.0"

--- a/vscode-smart-contracts/package.json
+++ b/vscode-smart-contracts/package.json
@@ -4,7 +4,7 @@
   "displayName": "Concordium Smart Contracts",
   "icon": "icon.png",
   "description": "Develop and build smart contracts on Concordium",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/Concordium/concordium-smart-contract-tools.git",

--- a/vscode-smart-contracts/scripts/macos-vscode-smart-contracts.Jenkinsfile
+++ b/vscode-smart-contracts/scripts/macos-vscode-smart-contracts.Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                 echo -n "$CARGO_CONCORDIUM_VERSION"
             '''.stripIndent()
         )
-        CARGO_CONCORDIUM_EXECUTABLE = "s3://distribution.concordium.software/tools/macos/signed/cargo-concordium_${CARGO_CONCORDIUM_VERSION}.zip"
+        CARGO_CONCORDIUM_EXECUTABLE = "s3://distribution.concordium.software/tools/macos/cargo-concordium_${CARGO_CONCORDIUM_VERSION}"
         OUTFILE_ARM64 = "s3://distribution.concordium.software/tools/macos/vscode-smart-contracts_${VERSION}-darwin-arm64.vsix"
         OUTFILE_X64 = "s3://distribution.concordium.software/tools/macos/vscode-smart-contracts_${VERSION}-darwin-x64.vsix"
     }
@@ -45,13 +45,7 @@ pipeline {
             steps {
                 sh '''\
                     # Download zipped cargo-concordium executable from S3.
-                    aws s3 cp "${CARGO_CONCORDIUM_EXECUTABLE}" tmp/cargo-concordium.zip
-
-                    unzip tmp/cargo-concordium.zip -d tmp
-
-                    # Move binary to right location
-                    mkdir vscode-smart-contracts/executables
-                    mv tmp/cargo-concordium_${CARGO_CONCORDIUM_VERSION} vscode-smart-contracts/executables/cargo-concordium
+                    aws s3 cp "${CARGO_CONCORDIUM_EXECUTABLE}" vscode-smart-contracts/executables/cargo-concordium
 
                     # Make binary executable.
                     chmod +x vscode-smart-contracts/executables/cargo-concordium

--- a/vscode-smart-contracts/scripts/windows-vscode-smart-contracts.Jenkinsfile
+++ b/vscode-smart-contracts/scripts/windows-vscode-smart-contracts.Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
                 echo -n "$CARGO_CONCORDIUM_VERSION"
             '''.stripIndent()
         )
-        CARGO_CONCORDIUM_EXECUTABLE = "s3://distribution.concordium.software/tools/windows/signed/cargo-concordium_${CARGO_CONCORDIUM_VERSION}.exe"
+        CARGO_CONCORDIUM_EXECUTABLE = "s3://distribution.concordium.software/tools/windows/cargo-concordium_${CARGO_CONCORDIUM_VERSION}.exe"
         OUTFILE = "s3://distribution.concordium.software/tools/windows/vscode-smart-contracts_${VERSION}.vsix"
     }
     stages {


### PR DESCRIPTION
## Purpose

Prepare release of vscode extension

## Changes

- Update changelog and release notes section for VS Code extension.
- Fix extension CI workflow by bumping the Rust version to match the other CI workflow.
- Change extension build jobs to download unsigned `cargo-concordium` binaries for Mac OS and Windows.

