### PR TITLE
Add padding to base64 output.

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.8.1
+
+- Add padding to base64 output to work around parsers that require it.
+
 ## 2.8.0
 
 - Non-existing directories in paths provided to the following arguments for when running `cargo concordium build` will now be created instead of causing an error: `--out`, `--schema-out`, `--schema-json-out`, `--schema-base64-out`.

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-concordium"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-concordium"
-version = "2.8.0"
+version = "2.8.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 license-file = "../LICENSE"

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -32,7 +32,7 @@ use std::{
 
 /// Encode all base64 strings using the standard alphabet and no padding.
 /// Padding is not useful since strings are just put as JSON strings.
-const ENCODER: base64::engine::GeneralPurpose = general_purpose::STANDARD_NO_PAD;
+const ENCODER: base64::engine::GeneralPurpose = general_purpose::STANDARD;
 
 fn to_snake_case(string: &str) -> String { string.to_lowercase().replace('-', "_") }
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -30,8 +30,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-/// Encode all base64 strings using the standard alphabet and no padding.
-/// Padding is not useful since strings are just put as JSON strings.
+/// Encode all base64 strings using the standard alphabet and padding.
 const ENCODER: base64::engine::GeneralPurpose = general_purpose::STANDARD;
 
 fn to_snake_case(string: &str) -> String { string.to_lowercase().replace('-', "_") }


### PR DESCRIPTION
## Purpose

Add padding to base64 output to support parsers that require it.

Padding does not serve a semantic purpose.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
