### PR TITLE
Update rust version in cargo-concordium windows build job

### DIFF
--- a/cargo-concordium/scripts/windows-cargo-concordium.Jenkinsfile
+++ b/cargo-concordium/scripts/windows-cargo-concordium.Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                     fi   
 
                     # Set rust env
-                    rustup default 1.62-x86_64-pc-windows-gnu
+                    rustup default 1.65-x86_64-pc-windows-gnu
 
                     cd cargo-concordium
 


### PR DESCRIPTION
## Purpose

Windows build job for cargo-concordium is failing because of outdated version of rust. This PR updates the rust version in the build job.
