### PR TITLE
Vscode install cargo-generate with  `--locked`

### DIFF
--- a/vscode-smart-contracts/CHANGELOG.md
+++ b/vscode-smart-contracts/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ## Unreleased
 
+## 1.0.3
+
+- Add `--locked` argument when installing `cargo-generate` for the user.
+
 ## 1.0.2
 
 - Update icon of the extension to better support dark themes.
 - Show an error when unable to determine the project, when running build and test commands.
 - Contains `cargo-concordium` version 2.8.1
+
 ## 1.0.1
 
 - Initial release

--- a/vscode-smart-contracts/README.md
+++ b/vscode-smart-contracts/README.md
@@ -53,6 +53,10 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+### 1.0.3
+
+- Add `--locked` argument when installing `cargo-generate` for the user.
+
 ### 1.0.2
 
 - Update icon of the extension to better support dark themes.

--- a/vscode-smart-contracts/package.json
+++ b/vscode-smart-contracts/package.json
@@ -4,7 +4,7 @@
   "displayName": "Concordium Smart Contracts",
   "icon": "icon.png",
   "description": "Develop and build smart contracts on Concordium",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/Concordium/concordium-smart-contract-tools.git",

--- a/vscode-smart-contracts/src/commands.ts
+++ b/vscode-smart-contracts/src/commands.ts
@@ -287,6 +287,7 @@ async function installCargoGenerate() {
   const execution = new vscode.ProcessExecution("cargo", [
     "install",
     "cargo-generate",
+    "--locked",
   ]);
   const task = new vscode.Task(
     {


### PR DESCRIPTION
## Purpose

Fix issue with `cargo-generate` failing to install https://github.com/cargo-generate/cargo-generate/issues/942.

## Changes

- Lock dependencies when installing `cargo-generate` for the user.
- Prepare for release of 1.0.3
