### PR TITLE
Implement `module_deploy_v1` for auto (re)compiling module to wasm

### DIFF
--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -13,6 +13,14 @@ include = ["Cargo.toml", "Cargo.lock", "src/*"] # Only include the actual source
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+name = "cargo_concordium_lib"
+path = "src/lib.rs"
+
+[[bin]]
+name = "cargo-concordium"
+path = "src/main.rs"
+
 [dependencies]
 clap = "2.33"
 structopt = "0.3"

--- a/cargo-concordium/src/lib.rs
+++ b/cargo-concordium/src/lib.rs
@@ -1,0 +1,6 @@
+//! The Cargo Concordium Library.
+//!
+//! Provides methods for compiling smart contracts to deployable Wasm modules.
+//! The library primarily exists to allow the [Concordium Smart Contract Testing](https://crates.io/crates/concordium-smart-contract-testing)
+//! library to automatically (re)build smart contract modules while testing.
+pub mod build;

--- a/concordium-smart-contract-testing/CHANGELOG.md
+++ b/concordium-smart-contract-testing/CHANGELOG.md
@@ -14,6 +14,7 @@
   - On the `ContractInvokeError` type:
     - Include the field `trace_elements` of type `Vec<DebugTraceElements>` with the trace elements that were hitherto discarded. (breaking change)
     - To migrate, include the new field or use `..` when pattern matching on the type.
+- Add the method `module_build_v1`, which automatically (re)compiles the current module to a deployable and testable Wasm module.
 
 ## 1.0.0
 

--- a/concordium-smart-contract-testing/Cargo.toml
+++ b/concordium-smart-contract-testing/Cargo.toml
@@ -16,6 +16,7 @@ exclude = ["tests"] # Do not publish tests.
 concordium_base = {version = "1.2", path = "../concordium-base/rust-src/concordium_base"}
 concordium-smart-contract-engine = {version = "1.2", path = "../concordium-base/smart-contracts/wasm-chain-integration"}
 concordium-wasm = {version = "1.1", path = "../concordium-base/smart-contracts/wasm-transform"}
+cargo-concordium = { version = "*", path = "../cargo-concordium" }
 sha2 = "0.10"
 anyhow = "1"
 thiserror = "1.0"

--- a/concordium-smart-contract-testing/src/lib.rs
+++ b/concordium-smart-contract-testing/src/lib.rs
@@ -89,7 +89,7 @@ mod constants;
 mod impls;
 mod invocation;
 mod types;
-pub use impls::{module_load_v1, module_load_v1_raw};
+pub use impls::{module_build_v1, module_load_v1, module_load_v1_raw};
 pub use types::*;
 
 // Re-export types.

--- a/concordium-smart-contract-testing/src/types.rs
+++ b/concordium-smart-contract-testing/src/types.rs
@@ -99,6 +99,12 @@ pub struct Transfer {
     pub to:     AccountAddress,
 }
 
+/// An error that occurred while building a module with
+/// [`crate::module_build_v1`].
+#[derive(Debug, Error)]
+#[error("Building the module failed due to: {0:?}")]
+pub struct ModuleBuildError(#[from] pub(crate) anyhow::Error);
+
 /// Represents a successful deployment of a [`ContractModule`].
 #[derive(Debug, PartialEq, Eq)]
 pub struct ModuleDeploySuccess {


### PR DESCRIPTION
## Purpose

Implement `module_deploy_v1` for auto (re)compiling module to a deployable and testable Wasm module.

The method makes use of the synchronization primitive https://doc.rust-lang.org/std/sync/struct.Once.html to ensure that the module is only built once, instead of one time per test case. `Once` makes sure to block the other test threads until the module has been produced.

Example usage:
```
    module_build_v1().expect("Building succeeds");

    let module =
        module_load_v1("./concordium-test-out/module.wasm.v1").expect("Module exists and is valid");
```

## Changes

- Add a library part to cargo concordium `cargo_concordium_lib` to reuse the building functionality from it.
  - This needs to be published as well, which is not ideal but seems ok.
- Add the method `module_deploy_v1`

## Tasks remaining
- [ ] Use the library in the piggy bank tests after publishing
- [ ] Document how to use it in the developer documentation
   - [ ] Remove warnings about recompilation in the developer docs or at least refer to this method.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.