### PR TITLE
Compile module and run integration tests when using `cargo concordium…

### DIFF
--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.65"
 readme = "README.md"
 description = "A tool to build and test smart contracts on the Concordium blockchain."
 homepage = "https://github.com/Concordium/concordium-smart-contract-tools"
-reposity = "https://github.com/Concordium/concordium-smart-contract-tools"
+repository = "https://github.com/Concordium/concordium-smart-contract-tools"
 include = ["Cargo.toml", "Cargo.lock", "src/*"] # Only include the actual sources.
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -2,6 +2,7 @@ use crate::{
     build::*,
     context::{InitContextOpt, ReceiveContextOpt, ReceiveContextV1Opt},
 };
+use ansi_term::Color;
 use anyhow::{bail, ensure, Context};
 use clap::AppSettings;
 use concordium_contracts_common::{
@@ -443,9 +444,14 @@ pub fn main() -> anyhow::Result<()> {
             }
         }
         Command::Test { args, seed } => {
-            let success =
+            let success_unit =
                 build_and_run_wasm_test(&args, seed).context("Could not build and run tests.")?;
-            ensure!(success, "Test failed");
+            let success_integration = build_and_run_integration_tests().is_ok();
+            if success_unit && success_integration {
+                eprintln!("{}", Color::Green.bold().paint("All tests passed"));
+            } else {
+                eprintln!("\n{}", Color::Red.bold().paint("One or more tests failed"));
+            };
         }
         Command::Init { path } => {
             init_concordium_project(path)


### PR DESCRIPTION
## Purpose

Extend `cargo concordium test` such that it compiles the module and runs all integration tests.

## Changes

- Make changes to the test handling.

## TODOs

- [ ] Should it output in `concordium-test-out` or `concordium-out` (also used by VSCode extension).
- [ ] Should we allow the user to specify
   - Where to output the module compiled
   - Schema options for building
   - Extra cargo args
   - Or will the above be handled by the user manually using `cargo concordium build`?
- [ ] Should it compile the module even when there are no integration tests?

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.