### PR TITLE
Add drop down for smart contract names

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+- Add `smart-contract-name` dropDown. The `smart-contract-names` are extracted from the module.
 - Add link to developer documentation
 
 ## 1.0.0

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "front-end-tools",
     "packageManager": "yarn@3.2.0",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/front-end-tools/src/index.css
+++ b/front-end-tools/src/index.css
@@ -107,3 +107,12 @@ label,
     margin: 7px 0px 7px 0px;
     padding: 10px 20px;
 }
+
+.dropDownStyle {
+    background-color: white;
+    box-sizing: border-box;
+    border-radius: 10px;
+    border: 1px solid #308274;
+    margin: 7px 0px 7px 0px;
+    padding: 9px 184px 9px 20px;
+  }


### PR DESCRIPTION
## Purpose

addresses #93 

## Changes

Add a drop-down element for all available smart contract names.

Users can now select the `smartContractName` that they want to initialize from a drop-down (This is available if the user checked the `Use Module from Step 1` checkbox). The smart contract names are extracted from the WASM module. A valid versioned WASM module needs to be given in step 1 to extract the smart contract names.
