### PR TITLE
Get template from moduleSchema

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,7 +1,20 @@
 ## Unreleased changes
 
+## 2.0.0
+
+- Add support for getting the embedded schema from the module.
+- Display schema template to user.
+
+## 1.3.0
+
 - Add link to source code.
+
+## 1.2.0
+
 - Add `smart-contract-name` dropDown. The `smart-contract-names` are extracted from the module.
+
+## 1.1.0
+
 - Add link to developer documentation
 
 ## 1.0.0

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -7,9 +7,8 @@
         "node": ">=16.x"
     },
     "dependencies": {
-        "@concordium/browser-wallet-api-helpers": "^2.5.0",
         "@concordium/react-components": "^0.3.0",
-        "@concordium/web-sdk": "^3.4.0",
+        "@concordium/web-sdk": "6.0.0",
         "@walletconnect/types": "^2.1.4",
         "eslint": "^8.37.0",
         "moment": "^2.29.4",

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "front-end-tools",
     "packageManager": "yarn@3.2.0",
-    "version": "1.3.0",
+    "version": "2.0.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -317,11 +317,11 @@ export default function Main(props: ConnectionProps) {
             } catch (e) {
                 if (useModuleFromStep1) {
                     setSchemaError(
-                        `Was not able to get embedded input parameter schema from uploaded module. Uncheck "Use Module from Step 1" checkbox to upload manually a schema. Orignial error: ${e}`
+                        `Could not get embedded input parameter schema from the uploaded module. Uncheck "Use Module from Step 1" checkbox to upload manually a schema. Original error: ${e}`
                     );
                 } else {
                     setSchemaError(
-                        `Was not able to get input parameter schema from uploaded schema. Orignial error: ${e}`
+                        `Could not get input parameter schema from uploaded schema. Original error: ${e}`
                     );
                 }
             }

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -23,7 +23,7 @@ import { WalletConnectionTypeButton } from './WalletConnectorTypeButton';
 
 import { initialize, deploy } from './writing_to_blockchain';
 
-import { BROWSER_WALLET, REFRESH_INTERVAL, DEFAULT_ARRAY_OBJECT, DEFAULT_JSON_OBJECT } from './constants';
+import { BROWSER_WALLET, REFRESH_INTERVAL, EXAMPLE_ARRAYS, EXAMPLE_JSON_OBJECT } from './constants';
 
 type TestBoxProps = PropsWithChildren<{
     header: string;
@@ -116,11 +116,11 @@ export default function Main(props: ConnectionProps) {
     function getObjectExample(template: string) {
         return template !== ''
             ? JSON.stringify(JSON.parse(template), undefined, 2)
-            : JSON.stringify(DEFAULT_JSON_OBJECT, undefined, 2);
+            : JSON.stringify(EXAMPLE_JSON_OBJECT, undefined, 2);
     }
 
     function getArrayExample(template: string) {
-        return template !== '' ? JSON.stringify(JSON.parse(template), undefined, 2) : DEFAULT_ARRAY_OBJECT;
+        return template !== '' ? JSON.stringify(JSON.parse(template), undefined, 2) : EXAMPLE_ARRAYS;
     }
 
     const changeModuleReferenceHandler = useCallback((event: ChangeEvent) => {
@@ -314,7 +314,7 @@ export default function Main(props: ConnectionProps) {
             } catch (e) {
                 if (useModuleFromStep1) {
                     setSchemaError(
-                        `Could not get embedded input parameter schema from the uploaded module. Uncheck "Use Module from Step 1" checkbox to upload manually a schema. Original error: ${e}`
+                        `Could not get embedded input parameter schema from the uploaded module. \nUncheck "Use Module from Step 1" checkbox to manually upload a schema. Original error: ${e}`
                     );
                 } else {
                     setSchemaError(`Could not get input parameter schema from uploaded schema. Original error: ${e}`);
@@ -673,12 +673,13 @@ export default function Main(props: ConnectionProps) {
                                     <>
                                         <br />
                                         <div>
-                                            This checkbox autofilled the `moduleReference`, the `contractNames`, and the
-                                            `embeddedInputParameterSchema` from the above module.
+                                            This checkbox autofilled the <code>module reference</code>, the{' '}
+                                            <code>smart contract name</code>, and the{' '}
+                                            <code>input parameter schema</code> from the above module.
                                         </div>
                                         <div>
-                                            If you want to load a new module from step 1, `uncheck` and `check` this box
-                                            again.
+                                            <b>Uncheck</b> and <b>check</b> this box again, if you want to
+                                            load a new module from step 1.
                                         </div>
                                         <br />
                                     </>

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -114,12 +114,13 @@ export default function Main(props: ConnectionProps) {
     }
 
     function getObjectExample(template: string) {
-        const obj = template !== '' ? JSON.parse(template) : JSON.stringify(DEFAULT_JSON_OBJECT);
-        return JSON.stringify(JSON.parse(obj), undefined, 2);
+        return template !== ''
+            ? JSON.stringify(JSON.parse(template), undefined, 2)
+            : JSON.stringify(DEFAULT_JSON_OBJECT, undefined, 2);
     }
 
     function getArrayExample(template: string) {
-        return template !== '' ? JSON.stringify(JSON.parse(JSON.parse(template)), undefined, 2) : DEFAULT_ARRAY_OBJECT;
+        return template !== '' ? JSON.stringify(JSON.parse(template), undefined, 2) : DEFAULT_ARRAY_OBJECT;
     }
 
     const changeModuleReferenceHandler = useCallback((event: ChangeEvent) => {
@@ -307,22 +308,16 @@ export default function Main(props: ConnectionProps) {
                     2
                 );
 
-                const stringifiedInputParameterTemplate = JSON.stringify(
-                    displayTypeSchemaTemplate(inputParamterTypeSchemaBuffer)
-                );
+                template = displayTypeSchemaTemplate(inputParamterTypeSchemaBuffer);
 
-                setInputParameterTemplate(stringifiedInputParameterTemplate);
-
-                template = stringifiedInputParameterTemplate;
+                setInputParameterTemplate(template);
             } catch (e) {
                 if (useModuleFromStep1) {
                     setSchemaError(
                         `Could not get embedded input parameter schema from the uploaded module. Uncheck "Use Module from Step 1" checkbox to upload manually a schema. Original error: ${e}`
                     );
                 } else {
-                    setSchemaError(
-                        `Could not get input parameter schema from uploaded schema. Original error: ${e}`
-                    );
+                    setSchemaError(`Could not get input parameter schema from uploaded schema. Original error: ${e}`);
                 }
             }
         }
@@ -863,11 +858,7 @@ export default function Main(props: ConnectionProps) {
                                             <div className="actionResultBox">
                                                 Input Parameter Template:
                                                 <pre>
-                                                    {JSON.stringify(
-                                                        JSON.parse(JSON.parse(inputParameterTemplate)),
-                                                        undefined,
-                                                        2
-                                                    )}
+                                                    {JSON.stringify(JSON.parse(inputParameterTemplate), undefined, 2)}
                                                 </pre>
                                             </div>
                                         )}

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -4,3 +4,14 @@ import moment from 'moment';
 export const REFRESH_INTERVAL = moment.duration(5, 'seconds');
 
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
+
+export const DEFAULT_JSON_OBJECT = {
+    myStringField: 'FieldValue',
+    myNumberField: 4,
+    myArray: [1, 2, 3],
+    myObject: {
+        myField1: 'FieldValue',
+    },
+};
+
+export const DEFAULT_ARRAY_OBJECT = 'Examples: \n\n[1,2,3] or \n\n["abc","def"] or \n\n[{"myFieldKey":"myFieldValue"}]';

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -5,7 +5,10 @@ export const REFRESH_INTERVAL = moment.duration(5, 'seconds');
 
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
 
-export const DEFAULT_JSON_OBJECT = {
+
+// This is the example JSON object that is shown in the input parameter textarea as a placeholder when the user has no embedded schema in the module 
+// or does not want to use the embedded schema (meaning if the checkbox "Use module from step 1" is unchecked).
+export const EXAMPLE_JSON_OBJECT = {
     myStringField: 'FieldValue',
     myNumberField: 4,
     myArray: [1, 2, 3],
@@ -14,4 +17,6 @@ export const DEFAULT_JSON_OBJECT = {
     },
 };
 
-export const DEFAULT_ARRAY_OBJECT = 'Examples: \n\n[1,2,3] or \n\n["abc","def"] or \n\n[{"myFieldKey":"myFieldValue"}]';
+// These are the example arrays that are shown in the input parameter textarea as a placeholder when the user has no embedded schema in the module 
+// or does not want to use the embedded schema (meaning if the checkbox "Use module from step 1" is unchecked).
+export const EXAMPLE_ARRAYS = 'Examples: \n\n[1,2,3] or \n\n["abc","def"] or \n\n[{"myFieldKey":"myFieldValue"}]';

--- a/front-end-tools/src/index.css
+++ b/front-end-tools/src/index.css
@@ -115,4 +115,4 @@ label,
     border: 1px solid #308274;
     margin: 7px 0px 7px 0px;
     padding: 9px 184px 9px 20px;
-  }
+}

--- a/front-end-tools/src/writing_to_blockchain.ts
+++ b/front-end-tools/src/writing_to_blockchain.ts
@@ -7,7 +7,7 @@ import {
     ModuleReference,
     toBuffer,
 } from '@concordium/web-sdk';
-import { WalletConnection } from '@concordium/react-components';
+import { WalletConnection, typeSchemaFromBase64 } from '@concordium/react-components';
 import { moduleSchemaFromBase64 } from '@concordium/wallet-connectors';
 
 export async function deploy(connection: WalletConnection, account: string, base64Module: string) {
@@ -27,7 +27,9 @@ export async function initialize(
     inputParameter: string,
     initName: string,
     hasInputParameter: boolean,
+    checkedBoxElemenChecked: boolean,
     contractSchema: string,
+    inputParamterTypeSchema: string,
     dropDown: string,
     maxContractExecutionEnergy: string,
     amount?: string
@@ -45,37 +47,49 @@ export async function initialize(
     }
 
     if (hasInputParameter) {
-        if (contractSchema === '') {
+        if (!checkedBoxElemenChecked && contractSchema === '') {
             throw new Error(`Set schema`);
+        }
+
+        if (checkedBoxElemenChecked && inputParamterTypeSchema === '') {
+            throw new Error(`No embedded input parameter schema found in module`);
         }
     }
 
     let schema;
 
-    if (contractSchema !== '') {
+    if (hasInputParameter) {
         switch (dropDown) {
             case 'number':
                 schema = {
                     parameters: Number(inputParameter),
-                    schema: moduleSchemaFromBase64(contractSchema),
+                    schema: checkedBoxElemenChecked
+                        ? typeSchemaFromBase64(inputParamterTypeSchema)
+                        : moduleSchemaFromBase64(contractSchema),
                 };
                 break;
             case 'string':
                 schema = {
                     parameters: inputParameter,
-                    schema: moduleSchemaFromBase64(contractSchema),
+                    schema: checkedBoxElemenChecked
+                        ? typeSchemaFromBase64(inputParamterTypeSchema)
+                        : moduleSchemaFromBase64(contractSchema),
                 };
                 break;
             case 'object':
                 schema = {
                     parameters: JSON.parse(inputParameter),
-                    schema: moduleSchemaFromBase64(contractSchema),
+                    schema: checkedBoxElemenChecked
+                        ? typeSchemaFromBase64(inputParamterTypeSchema)
+                        : moduleSchemaFromBase64(contractSchema),
                 };
                 break;
             case 'array':
                 schema = {
                     parameters: JSON.parse(inputParameter),
-                    schema: moduleSchemaFromBase64(contractSchema),
+                    schema: checkedBoxElemenChecked
+                        ? typeSchemaFromBase64(inputParamterTypeSchema)
+                        : moduleSchemaFromBase64(contractSchema),
                 };
                 break;
             default:

--- a/front-end-tools/yarn.lock
+++ b/front-end-tools/yarn.lock
@@ -289,6 +289,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@concordium/common-sdk@npm:9.0.0":
+  version: 9.0.0
+  resolution: "@concordium/common-sdk@npm:9.0.0"
+  dependencies:
+    "@concordium/rust-bindings": 1.1.0
+    "@grpc/grpc-js": ^1.3.4
+    "@noble/ed25519": ^1.7.1
+    "@protobuf-ts/runtime-rpc": ^2.8.2
+    "@scure/bip39": ^1.1.0
+    bs58check: ^2.1.2
+    buffer: ^6.0.3
+    cross-fetch: 3.1.5
+    hash.js: ^1.1.7
+    iso-3166-1: ^2.1.1
+    json-bigint: ^1.0.0
+    uuid: ^8.3.2
+  checksum: b640846415dfb18b4bb549519ab7fa7825c6b5e84adf1cfaeeea89bb54341e5176e71f00b732ea9bb375aac938842434ab1d6d5ffe2a5f360efc236ea5b0ef4a
+  languageName: node
+  linkType: hard
+
 "@concordium/react-components@npm:^0.3.0":
   version: 0.3.0
   resolution: "@concordium/react-components@npm:0.3.0"
@@ -307,6 +327,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@concordium/rust-bindings@npm:1.1.0":
+  version: 1.1.0
+  resolution: "@concordium/rust-bindings@npm:1.1.0"
+  checksum: 4890306b5df5fb85012cc6c6a6daf15ec1d24c528ac487a4547e8758738a1205b2386a1d4b015dc45312811466d853819edff4b9921d3674afe13ade5cacc061
+  languageName: node
+  linkType: hard
+
 "@concordium/wallet-connectors@npm:^0.3.1":
   version: 0.3.1
   resolution: "@concordium/wallet-connectors@npm:0.3.1"
@@ -318,7 +345,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@concordium/web-sdk@npm:^3.4.0, @concordium/web-sdk@npm:^3.4.2":
+"@concordium/web-sdk@npm:6.0.0":
+  version: 6.0.0
+  resolution: "@concordium/web-sdk@npm:6.0.0"
+  dependencies:
+    "@concordium/common-sdk": 9.0.0
+    "@concordium/rust-bindings": 1.1.0
+    "@grpc/grpc-js": ^1.3.4
+    "@protobuf-ts/grpcweb-transport": ^2.8.2
+    buffer: ^6.0.3
+    process: ^0.11.10
+  checksum: 23cfda2813ed86ed165f427edab237e5c20af70405d450541479294a1093b60843ce9d7f8a2dbeb69e174e0aed0ec51bee109e0fb7e22f121bff5c11c4bb24de
+  languageName: node
+  linkType: hard
+
+"@concordium/web-sdk@npm:^3.4.2":
   version: 3.5.0
   resolution: "@concordium/web-sdk@npm:3.5.0"
   dependencies:
@@ -4132,9 +4173,8 @@ cors@latest:
   version: 0.0.0-use.local
   resolution: "front-end-tools@workspace:."
   dependencies:
-    "@concordium/browser-wallet-api-helpers": ^2.5.0
     "@concordium/react-components": ^0.3.0
-    "@concordium/web-sdk": ^3.4.0
+    "@concordium/web-sdk": 6.0.0
     "@craftamap/esbuild-plugin-html": ^0.4.0
     "@types/node": ^18.7.23
     "@types/react": ^18.0.9


### PR DESCRIPTION
## Purpose

closes #94 

- Making use of the embedded schemas in the module to simplify the user flow. The front end also displays the schema `template` to the user now.

## Changes

- When the user checks the `Use Module from Step 1` checkbox, the input parameter schema is extracted from the uploaded module (in case the module has an embedded schema). The template of this embedded input parameter schema is shown to the user. No manual upload of the schema is needed anymore in this case.

- The template of the schema is also displayed when the user manually uploads a `schema.bin` file, a corresponding/valid `contract_name` has to be given at the same time for the front end to display the schema.

Scope: Extracting embedded schemas and the template display works from `myContract.wasm.v1`/`schema.bin` files that are created with the current Concordium tooling. It was decided to be out of scope to investigate if it works for very old modules/schemas that were created in the past since it won't add a lot of value (most users want to deploy a module that they currently actively develop)
