### PR TITLE
Add link to source code

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+- Add link to source code.
 - Add `smart-contract-name` dropDown. The `smart-contract-names` are extracted from the module.
 - Add link to developer documentation
 

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "front-end-tools",
     "packageManager": "yarn@3.2.0",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -894,6 +894,15 @@ export default function Main(props: ConnectionProps) {
                                 Learn more about how deployment and initialization works on Concordium.
                             </a>
                             <br />
+                            <br />
+                            <a
+                                href="https://github.com/Concordium/concordium-smart-contract-tools/tree/main/front-end-tools"
+                                target="_blank"
+                                rel="noreferrer"
+                            >
+                                Front end source code
+                            </a>
+                            <br />
                         </div>
                     )}
                 </div>


### PR DESCRIPTION
## Purpose

All hosted front ends should have a way to find the source code easily. Either through a link to an associated tutorial (that contains links to the source code) or if no tutorial exists through a link to the source code.

## Changes

Add link to source code.
