### PR TITLE
Fix the order of expected arguments to match the node.

### DIFF
--- a/concordium-smart-contract-testing/src/invocation/impls.rs
+++ b/concordium-smart-contract-testing/src/invocation/impls.rs
@@ -1416,10 +1416,11 @@ fn deserial_signature_and_data_from_contract(
     // trait.
     use concordium_base::contracts_common::Deserial;
     let mut source = concordium_base::contracts_common::Cursor::new(payload);
-
-    let signatures = AccountSignatures::deserial(&mut source)?;
     let data_len = u32::deserial(&mut source)?;
-    Ok((signatures, &payload[source.offset..][..data_len as usize]))
+    let data = &payload[source.offset..][..data_len as usize];
+    source.offset += data_len as usize;
+    let signatures = AccountSignatures::deserial(&mut source)?;
+    Ok((signatures, data))
 }
 
 impl ChangeSet {
@@ -1505,7 +1506,7 @@ impl ChangeSet {
 
         // Then persist all the changes.
         for (addr, changes) in current.contracts.iter_mut() {
-            let mut contract = persisted_contracts
+            let contract = persisted_contracts
                 .get_mut(addr)
                 .expect("Precondition violation: contract must exist");
             // Update balance.
@@ -1532,7 +1533,7 @@ impl ChangeSet {
         }
         // Persist account changes.
         for (addr, changes) in current.accounts.iter() {
-            let mut account = persisted_accounts
+            let account = persisted_accounts
                 .get_mut(addr)
                 .expect("Precondition violation: account must exist");
             // Update balance.

--- a/concordium-smart-contract-testing/tests/account-signature-checks.rs
+++ b/concordium-smart-contract-testing/tests/account-signature-checks.rs
@@ -118,7 +118,7 @@ fn test() {
             UpdateContractPayload {
                 address:      res_init.contract_address,
                 receive_name: OwnedReceiveName::new_unchecked("contract.check_signature".into()),
-                message:      OwnedParameter::from_serial(&(ACC_0, &signatures, data))
+                message:      OwnedParameter::from_serial(&(ACC_0, data, &signatures))
                     .expect("Enough space."),
                 amount:       Amount::zero(),
             },


### PR DESCRIPTION
## Purpose

Fix the order of arguments to check signature so that it matches the node.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
