### PR TITLE
Fix check if module is deployed already in step 2

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.1.0
 
-- Fix the `isModuleReferenceAlreadyDeployedStep2` check. `isModuleReferenceAlreadyDeployedStep2` uses the module reference from the input field in step 2 while the `isModuleReferenceAlreadyDeployedStep1` uses the module reference from the calculation in step 1.
+- Fix check if module is already deployed in step 2.
 
 ## 2.0.0
 

--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.1.0
+
+- Fix the `isModuleReferenceAlreadyDeployedStep2` check. `isModuleReferenceAlreadyDeployedStep2` uses the module reference from the input field in step 2 while the `isModuleReferenceAlreadyDeployedStep1` uses the module reference from the calculation in step 1.
+
 ## 2.0.0
 
 - Add support for getting the embedded schema from the module.

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "front-end-tools",
     "packageManager": "yarn@3.2.0",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -67,7 +67,8 @@ export default function Main(props: ConnectionProps) {
 
     const [accountExistsOnNetwork, setAccountExistsOnNetwork] = useState(true);
     const [moduleReferenceCalculated, setModuleReferenceCalculated] = useState('');
-    const [moduleReferenceAlreadyDeployed, setModuleReferenceAlreadyDeployed] = useState(false);
+    const [isModuleReferenceAlreadyDeployedStep1, setIsModuleReferenceAlreadyDeployedStep1] = useState(false);
+    const [isModuleReferenceAlreadyDeployedStep2, setIsModuleReferenceAlreadyDeployedStep2] = useState(false);
     const [moduleReferenceDeployed, setModuleReferenceDeployed] = useState('');
 
     const [txHashDeploy, setTxHashDeploy] = useState('');
@@ -283,16 +284,33 @@ export default function Main(props: ConnectionProps) {
                 .getModuleSource(new ModuleReference(moduleReferenceCalculated))
                 .then((value) => {
                     if (value === undefined) {
-                        setModuleReferenceAlreadyDeployed(false);
+                        setIsModuleReferenceAlreadyDeployedStep1(false);
                     } else {
-                        setModuleReferenceAlreadyDeployed(true);
+                        setIsModuleReferenceAlreadyDeployedStep1(true);
                     }
                 })
                 .catch(() => {
-                    setModuleReferenceAlreadyDeployed(false);
+                    setIsModuleReferenceAlreadyDeployedStep1(false);
                 });
         }
     }, [connection, account, client, moduleReferenceCalculated]);
+
+    useEffect(() => {
+        if (connection && client && account && moduleReference) {
+            client
+                .getModuleSource(new ModuleReference(moduleReference))
+                .then((value) => {
+                    if (value === undefined) {
+                        setIsModuleReferenceAlreadyDeployedStep2(false);
+                    } else {
+                        setIsModuleReferenceAlreadyDeployedStep2(true);
+                    }
+                })
+                .catch(() => {
+                    setIsModuleReferenceAlreadyDeployedStep2(false);
+                });
+        }
+    }, [connection, account, client, moduleReference]);
 
     useEffect(() => {
         setSchemaError('');
@@ -553,13 +571,13 @@ export default function Main(props: ConnectionProps) {
                                             Module in base64:
                                             <div>{base64Module.toString().slice(0, 30)} ...</div>
                                         </div>
-                                        {moduleReferenceAlreadyDeployed && (
+                                        {isModuleReferenceAlreadyDeployedStep1 && (
                                             <div className="alert alert-danger" role="alert">
                                                 Module reference already deployed.
                                             </div>
                                         )}
                                         <br />
-                                        {!moduleReferenceAlreadyDeployed && (
+                                        {!isModuleReferenceAlreadyDeployedStep1 && (
                                             <button
                                                 className="btn btn-primary"
                                                 type="button"
@@ -678,8 +696,8 @@ export default function Main(props: ConnectionProps) {
                                             <code>input parameter schema</code> from the above module.
                                         </div>
                                         <div>
-                                            <b>Uncheck</b> and <b>check</b> this box again, if you want to
-                                            load a new module from step 1.
+                                            <b>Uncheck</b> and <b>check</b> this box again, if you want to load a new
+                                            module from step 1.
                                         </div>
                                         <br />
                                     </>
@@ -938,7 +956,7 @@ export default function Main(props: ConnectionProps) {
                                         const tx = initialize(
                                             connection,
                                             account,
-                                            moduleReferenceAlreadyDeployed,
+                                            isModuleReferenceAlreadyDeployedStep2,
                                             moduleReference,
                                             inputParameter,
                                             contractName,

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -5,8 +5,7 @@ export const REFRESH_INTERVAL = moment.duration(5, 'seconds');
 
 export const BROWSER_WALLET = ephemeralConnectorType(BrowserWalletConnector.create);
 
-
-// This is the example JSON object that is shown in the input parameter textarea as a placeholder when the user has no embedded schema in the module 
+// This is the example JSON object that is shown in the input parameter textarea as a placeholder when the user has no embedded schema in the module
 // or does not want to use the embedded schema (meaning if the checkbox "Use module from step 1" is unchecked).
 export const EXAMPLE_JSON_OBJECT = {
     myStringField: 'FieldValue',
@@ -17,6 +16,6 @@ export const EXAMPLE_JSON_OBJECT = {
     },
 };
 
-// These are the example arrays that are shown in the input parameter textarea as a placeholder when the user has no embedded schema in the module 
+// These are the example arrays that are shown in the input parameter textarea as a placeholder when the user has no embedded schema in the module
 // or does not want to use the embedded schema (meaning if the checkbox "Use module from step 1" is unchecked).
 export const EXAMPLE_ARRAYS = 'Examples: \n\n[1,2,3] or \n\n["abc","def"] or \n\n[{"myFieldKey":"myFieldValue"}]';


### PR DESCRIPTION
## Purpose

- Fix the `isModuleReferenceAlreadyDeployedStep2` check. The current hosted front end does not allow a user to immediately jump to step 2 and initialize a module by inputting a module reference e.g. obtained from looking it up on a block explorer.

## Changes

- `IsModuleReferenceAlreadyDeployedStep2` uses the module reference from the input field in step 2. 
- `isModuleReferenceAlreadyDeployedStep1` uses the module reference from the calculation in step 1.
