### PR TITLE
Add warning boxes for some edge cases

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.2.0
+
+- Add warning box if module references in step 1 and step 2 are not the same. Add warning box if embedded schema indicates an input parameter but no input parameter is provided.
+
 ## 2.1.0
 
 - Fix check if module is already deployed in step 2.

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "front-end-tools",
     "packageManager": "yarn@3.2.0",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -73,7 +73,7 @@ export default function Main(props: ConnectionProps) {
     const [moduleReferenceDeployed, setModuleReferenceDeployed] = useState('');
 
     const [shouldWarnDifferenceModuleReferences, setShouldWarnDifferenceModuleReferences] = useState(false);
-    const [shouldWarnInputPramaterInSchemaIgnored, setShouldWarnInputPramaterInSchemaIgnored] = useState(false);
+    const [shouldWarnInputParameterInSchemaIgnored, setShouldWarnInputParameterInSchemaIgnored] = useState(false);
 
     const [txHashDeploy, setTxHashDeploy] = useState('');
     const [txHashInit, setTxHashInit] = useState('');
@@ -340,9 +340,9 @@ export default function Main(props: ConnectionProps) {
 
     useEffect(() => {
         if (inputParameterTemplate !== '' && hasInputParameter === false) {
-            setShouldWarnInputPramaterInSchemaIgnored(true);
+            setShouldWarnInputParameterInSchemaIgnored(true);
         } else {
-            setShouldWarnInputPramaterInSchemaIgnored(false);
+            setShouldWarnInputParameterInSchemaIgnored(false);
         }
     }, [inputParameterTemplate, hasInputParameter]);
 
@@ -1037,7 +1037,7 @@ export default function Main(props: ConnectionProps) {
                                         Warning: Module references in step 1 and step 2 are different.
                                     </div>
                                 )}
-                                {shouldWarnInputPramaterInSchemaIgnored && (
+                                {shouldWarnInputParameterInSchemaIgnored && (
                                     <div className="alert alert-warning" role="alert">
                                         Warning: Input parameter schema found but &quot;Has Input Parameter&quot;
                                         checkbox is unchecked.

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -641,22 +641,28 @@ export default function Main(props: ConnectionProps) {
                                 )}
                                 {txHashDeploy && (
                                     <>
-                                        <div>Transaction hash:</div>
-                                        <div>CCDScan will take a moment to pick up the transaction.</div>
+                                        <div>
+                                            Transaction hash:{' '}
+                                            <a
+                                                className="link"
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                href={`https://${
+                                                    isTestnet ? `testnet.` : ``
+                                                }ccdscan.io/?dcount=1&dentity=transaction&dhash=${txHashDeploy}`}
+                                            >
+                                                {txHashDeploy}
+                                            </a>
+                                        </div>
+                                        <br />
+                                        <div>
+                                            CCDScan will take a moment to pick up the above transaction, hence the above
+                                            link will work in a bit.
+                                        </div>
                                         <div>
                                             Deployed module reference will appear below once the transaction is
                                             finalized.
                                         </div>
-                                        <a
-                                            className="link"
-                                            target="_blank"
-                                            rel="noreferrer"
-                                            href={`https://${
-                                                isTestnet ? `testnet.` : ``
-                                            }ccdscan.io/?dcount=1&dentity=transaction&dhash=${txHashDeploy}`}
-                                        >
-                                            {txHashDeploy}
-                                        </a>
                                     </>
                                 )}
                                 {moduleReferenceDeployed && (
@@ -1050,22 +1056,28 @@ export default function Main(props: ConnectionProps) {
                                 )}
                                 {txHashInit && (
                                     <>
-                                        <div>Transaction hash:</div>
-                                        <div>CCDScan will take a moment to pick up the transaction.</div>
                                         <div>
-                                            New smart contract index will appear below once the transaction is
+                                            Transaction hash:{' '}
+                                            <a
+                                                className="link"
+                                                target="_blank"
+                                                rel="noreferrer"
+                                                href={`https://${
+                                                    isTestnet ? `testnet.` : ``
+                                                }ccdscan.io/?dcount=1&dentity=transaction&dhash=${txHashInit}`}
+                                            >
+                                                {txHashInit}
+                                            </a>
+                                        </div>
+                                        <br />
+                                        <div>
+                                            CCDScan will take a moment to pick up the above transaction, hence the above
+                                            link will work in a bit.
+                                        </div>
+                                        <div>
+                                            The smart contract index will appear below once the transaction is
                                             finalized.
                                         </div>
-                                        <a
-                                            className="link"
-                                            target="_blank"
-                                            rel="noreferrer"
-                                            href={`https://${
-                                                isTestnet ? `testnet.` : ``
-                                            }ccdscan.io/?dcount=1&dentity=transaction&dhash=${txHashInit}`}
-                                        >
-                                            {txHashInit}
-                                        </a>
                                     </>
                                 )}
                                 <br />


### PR DESCRIPTION
## Purpose

Collection of improvements to give better feedback to the user in some edge cases that likely are caused by the user's wrong input.

## Changes

- Add a warning box if module references in step 1 and step 2 are not the same. 
- Add a warning box if embedded schema indicates an input parameter but no input parameter is provided.
- Add check if inputted module reference has the correct length.
- Module reference input field is now disabled if the user checked `Use Module From Step 1` check box to avoid some edge cases.
- Revised some text displayed to the user
