### PR TITLE
Add support for the `--manifest-path` flag

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Add support for `--manifest-path` flag
+- Add support for `--manifest-path` flag.
 - Add `schema-template` command to print the template of a given schema to a file or the console.
 - Add `--schema-template-out` option to `cargo concordium build` to optionally output the schema template to a file or the console.
 - Make `cargo-concordium` compatible with protocol 6 semantics on the chain. In

--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Add support for `--manifest-path` flag
 - Add `schema-template` command to print the template of a given schema to a file or the console.
 - Add `--schema-template-out` option to `cargo concordium build` to optionally output the schema template to a file or the console.
 - Make `cargo-concordium` compatible with protocol 6 semantics on the chain. In

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -58,7 +58,10 @@ fn get_crate_metadata(cargo_args: &[String]) -> anyhow::Result<Metadata> {
         }
         Some(p) => {
             // If a `--manifest-path` is provided, look for the `Cargo.toml` file there.
-            cmd.manifest_path(p.trim_start_matches("--manifest-path="));
+            cmd.manifest_path(
+                p.strip_prefix("--manifest-path=")
+                    .context("Incorrect `--manifest-path` flag.")?,
+            );
         }
         None => {
             // If NO `--manifest-path` is provided, look for the `Cargo.toml`
@@ -746,13 +749,13 @@ pub(crate) fn build_and_run_integration_tests(
     build_options: BuildOptions,
     test_targets: Vec<String>,
 ) -> anyhow::Result<()> {
-    let cargo_args = build_options.cargo_args.clone();
+    let cargo_args = &build_options.cargo_args.clone();
 
     // Build the module in the same way as `cargo concordium build`, except that
     // schema information shouldn't be printed.
     crate::handle_build(build_options, false)?;
 
-    let metadata = get_crate_metadata(&cargo_args)?;
+    let metadata = get_crate_metadata(cargo_args)?;
 
     let mut cargo_test_args = vec!["test"];
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -116,7 +116,7 @@ pub fn build_contract(
         }
     };
 
-    let (target_dir, metadata) = if cargo_args.contains(&String::from("--manifest-path")) {
+    let metadata = if cargo_args.contains(&String::from("--manifest-path")) {
         // If a `--manifest-path` flag is provided use this path as the package root to
         // build the project
         let index = cargo_args
@@ -126,33 +126,18 @@ pub fn build_contract(
 
         let manifest_path_flag = &cargo_args[index + 1];
 
-        let metadata = MetadataCommand::new()
+        MetadataCommand::new()
             .manifest_path(manifest_path_flag)
             .exec()
-            .context("Could not access cargo metadata.")?;
-
-        let lengh = manifest_path_flag.len();
-
-        let mut manifest_path_flag_truncated = cargo_args[index + 1].clone();
-
-        // We remove the `/Cargo.toml` expression at the end of the path.
-        manifest_path_flag_truncated.truncate(lengh - 11);
-
-        (
-            format!("{}/target/concordium", manifest_path_flag_truncated),
-            metadata,
-        )
+            .context("Could not access cargo metadata.")?
     } else {
         // Use the package root to build the project
-        let metadata = MetadataCommand::new()
+        MetadataCommand::new()
             .exec()
-            .context("Could not access cargo metadata.")?;
-
-        (
-            format!("{}/concordium", metadata.target_directory),
-            metadata,
-        )
+            .context("Could not access cargo metadata.")?
     };
+
+    let target_dir = format!("{}/concordium", metadata.target_directory);
 
     let package = metadata
         .root_package()
@@ -364,7 +349,7 @@ pub fn build_contract_schema<A>(
     cargo_args: &[String],
     generate_schema: impl FnOnce(&[u8]) -> ExecResult<A>,
 ) -> anyhow::Result<A> {
-    let (target_dir, metadata) = if cargo_args.contains(&String::from("--manifest-path")) {
+    let metadata = if cargo_args.contains(&String::from("--manifest-path")) {
         // If a `--manifest-path` flag is provided use this path as the package root to
         // build the schemas
         let index = cargo_args
@@ -374,33 +359,18 @@ pub fn build_contract_schema<A>(
 
         let manifest_path_flag = &cargo_args[index + 1];
 
-        let metadata = MetadataCommand::new()
+        MetadataCommand::new()
             .manifest_path(manifest_path_flag)
             .exec()
-            .context("Could not access cargo metadata.")?;
-
-        let lengh = manifest_path_flag.len();
-
-        let mut manifest_path_flag_truncated = cargo_args[index + 1].clone();
-
-        // We remove the `/Cargo.toml` expression at the end of the path.
-        manifest_path_flag_truncated.truncate(lengh - 11);
-
-        (
-            format!("{}/target/concordium", manifest_path_flag_truncated),
-            metadata,
-        )
+            .context("Could not access cargo metadata.")?
     } else {
         // Use the package root to build the schemas
-        let metadata = MetadataCommand::new()
+        MetadataCommand::new()
             .exec()
-            .context("Could not access cargo metadata.")?;
-
-        (
-            format!("{}/concordium", metadata.target_directory),
-            metadata,
-        )
+            .context("Could not access cargo metadata.")?
     };
+
+    let target_dir = format!("{}/concordium", metadata.target_directory);
 
     let package = metadata
         .root_package()
@@ -881,7 +851,7 @@ pub(crate) fn build_and_run_integration_tests(
 /// The `seed` argument allows for providing the seed to instantiate a random
 /// number generator. If `None` is given, a random seed will be sampled.
 pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyhow::Result<bool> {
-    let (target_dir, metadata) = if extra_args.contains(&String::from("--manifest-path")) {
+    let metadata = if extra_args.contains(&String::from("--manifest-path")) {
         // If a `--manifest-path` flag is provided use this path as the package root to
         // test the project
         let index = extra_args
@@ -891,33 +861,18 @@ pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyh
 
         let manifest_path_flag = &extra_args[index + 1];
 
-        let metadata = MetadataCommand::new()
+        MetadataCommand::new()
             .manifest_path(manifest_path_flag)
             .exec()
-            .context("Could not access cargo metadata.")?;
-
-        let lengh = manifest_path_flag.len();
-
-        let mut manifest_path_flag_truncated = extra_args[index + 1].clone();
-
-        // We remove the `/Cargo.toml` expression at the end of the path.
-        manifest_path_flag_truncated.truncate(lengh - 11);
-
-        (
-            format!("{}/target/concordium", manifest_path_flag_truncated),
-            metadata,
-        )
+            .context("Could not access cargo metadata.")?
     } else {
         // Use the package root to test the project
-        let metadata = MetadataCommand::new()
+        MetadataCommand::new()
             .exec()
-            .context("Could not access cargo metadata.")?;
-
-        (
-            format!("{}/concordium", metadata.target_directory),
-            metadata,
-        )
+            .context("Could not access cargo metadata.")?
     };
+
+    let target_dir = format!("{}/concordium", metadata.target_directory);
 
     let package = metadata
         .root_package()

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -116,26 +116,27 @@ pub fn build_contract(
         }
     };
 
-    let metadata = if cargo_args.contains(&String::from("--manifest-path")) {
-        // If a `--manifest-path` flag is provided use this path as the package root to
-        // build the project
-        let index = cargo_args
-            .iter()
-            .position(|cargo_arg| cargo_arg == "--manifest-path")
-            .context("Could not get the index of the `--manifest-path` flag.")?;
+    let mut args = std::env::args().skip_while(|val| !val.starts_with("--manifest-path"));
 
-        let manifest_path_flag = &cargo_args[index + 1];
-
-        MetadataCommand::new()
-            .manifest_path(manifest_path_flag)
-            .exec()
-            .context("Could not access cargo metadata.")?
-    } else {
-        // Use the package root to build the project
-        MetadataCommand::new()
-            .exec()
-            .context("Could not access cargo metadata.")?
+    let mut cmd = MetadataCommand::new();
+    match args.next() {
+        Some(ref p) if p == "--manifest-path" => {
+            // If a `--manifest-path` is provided use this path as the package root to
+            // build the project.
+            cmd.manifest_path(args.next().context(
+                "The argument '--manifest-path <manifest-path>' requires a value but none was \
+                 supplied.",
+            )?);
+        }
+        Some(p) => {
+            // If a `--manifest-path` is provided use this path as the package root to
+            // build the project.
+            cmd.manifest_path(p.trim_start_matches("--manifest-path="));
+        }
+        None => {}
     };
+
+    let metadata = cmd.exec().context("Could not access cargo metadata.")?;
 
     let target_dir = format!("{}/concordium", metadata.target_directory);
 
@@ -349,26 +350,27 @@ pub fn build_contract_schema<A>(
     cargo_args: &[String],
     generate_schema: impl FnOnce(&[u8]) -> ExecResult<A>,
 ) -> anyhow::Result<A> {
-    let metadata = if cargo_args.contains(&String::from("--manifest-path")) {
-        // If a `--manifest-path` flag is provided use this path as the package root to
-        // build the schemas
-        let index = cargo_args
-            .iter()
-            .position(|cargo_arg| cargo_arg == "--manifest-path")
-            .context("Could not get the index of the `--manifest-path` flag.")?;
+    let mut args = std::env::args().skip_while(|val| !val.starts_with("--manifest-path"));
 
-        let manifest_path_flag = &cargo_args[index + 1];
-
-        MetadataCommand::new()
-            .manifest_path(manifest_path_flag)
-            .exec()
-            .context("Could not access cargo metadata.")?
-    } else {
-        // Use the package root to build the schemas
-        MetadataCommand::new()
-            .exec()
-            .context("Could not access cargo metadata.")?
+    let mut cmd = MetadataCommand::new();
+    match args.next() {
+        Some(ref p) if p == "--manifest-path" => {
+            // If a `--manifest-path` is provided use this path as the package root to
+            // build the schema.
+            cmd.manifest_path(args.next().context(
+                "The argument '--manifest-path <manifest-path>' requires a value but none was \
+                 supplied.",
+            )?);
+        }
+        Some(p) => {
+            // If a `--manifest-path` is provided use this path as the package root to
+            // build the schema.
+            cmd.manifest_path(p.trim_start_matches("--manifest-path="));
+        }
+        None => {}
     };
+
+    let metadata = cmd.exec().context("Could not access cargo metadata.")?;
 
     let target_dir = format!("{}/concordium", metadata.target_directory);
 
@@ -761,26 +763,27 @@ pub(crate) fn build_and_run_integration_tests(
     // schema information shouldn't be printed.
     crate::handle_build(build_options, false)?;
 
-    let metadata = if cargo_args.contains(&String::from("--manifest-path")) {
-        // If a `--manifest-path` flag is provided use this path as the package root to
-        // test the project
-        let index = cargo_args
-            .iter()
-            .position(|cargo_arg| cargo_arg == "--manifest-path")
-            .context("Could not get the index of the `--manifest-path` flag.")?;
+    let mut args = std::env::args().skip_while(|val| !val.starts_with("--manifest-path"));
 
-        let manifest_path_flag = &cargo_args[index + 1];
-
-        MetadataCommand::new()
-            .manifest_path(manifest_path_flag)
-            .exec()
-            .context("Could not access cargo metadata.")?
-    } else {
-        // Use the package root to test the project
-        MetadataCommand::new()
-            .exec()
-            .context("Could not access cargo metadata.")?
+    let mut cmd = MetadataCommand::new();
+    match args.next() {
+        Some(ref p) if p == "--manifest-path" => {
+            // If a `--manifest-path` is provided use this path as the package root to
+            // test the project.
+            cmd.manifest_path(args.next().context(
+                "The argument '--manifest-path <manifest-path>' requires a value but none was \
+                 supplied.",
+            )?);
+        }
+        Some(p) => {
+            // If a `--manifest-path` is provided use this path as the package root to
+            // test the project.
+            cmd.manifest_path(p.trim_start_matches("--manifest-path="));
+        }
+        None => {}
     };
+
+    let metadata = cmd.exec().context("Could not access cargo metadata.")?;
 
     let mut cargo_test_args = vec!["test"];
 
@@ -851,26 +854,27 @@ pub(crate) fn build_and_run_integration_tests(
 /// The `seed` argument allows for providing the seed to instantiate a random
 /// number generator. If `None` is given, a random seed will be sampled.
 pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyhow::Result<bool> {
-    let metadata = if extra_args.contains(&String::from("--manifest-path")) {
-        // If a `--manifest-path` flag is provided use this path as the package root to
-        // test the project
-        let index = extra_args
-            .iter()
-            .position(|cargo_arg| cargo_arg == "--manifest-path")
-            .context("Could not get the index of the `--manifest-path` flag.")?;
+    let mut args = std::env::args().skip_while(|val| !val.starts_with("--manifest-path"));
 
-        let manifest_path_flag = &extra_args[index + 1];
-
-        MetadataCommand::new()
-            .manifest_path(manifest_path_flag)
-            .exec()
-            .context("Could not access cargo metadata.")?
-    } else {
-        // Use the package root to test the project
-        MetadataCommand::new()
-            .exec()
-            .context("Could not access cargo metadata.")?
+    let mut cmd = MetadataCommand::new();
+    match args.next() {
+        Some(ref p) if p == "--manifest-path" => {
+            // If a `--manifest-path` is provided use this path as the package root to
+            // test the project.
+            cmd.manifest_path(args.next().context(
+                "The argument '--manifest-path <manifest-path>' requires a value but none was \
+                 supplied.",
+            )?);
+        }
+        Some(p) => {
+            // If a `--manifest-path` is provided use this path as the package root to
+            // test the project.
+            cmd.manifest_path(p.trim_start_matches("--manifest-path="));
+        }
+        None => {}
     };
+
+    let metadata = cmd.exec().context("Could not access cargo metadata.")?;
 
     let target_dir = format!("{}/concordium", metadata.target_directory);
 


### PR DESCRIPTION
## Purpose

Add support for the `--manifest-path` flag.

## Changes
Add support for the `cargo` native flag `--manifest-path`. The following commands are now working:

```cargo concordium build -- --manifest-path ./path/to/my/project/Cargo.toml```
```cargo concordium test -- --manifest-path ./path/to/my/project/Cargo.toml```

