### PR TITLE
Reproducible builds

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 3.1.0
+
+- Support verifiable/reproducible builds.
+
 ## 3.0.0
 
 - Add support for `--manifest-path` flag.

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -262,9 +262,9 @@ dependencies = [
  "base64",
  "cargo_metadata",
  "clap",
- "concordium-contracts-common",
  "concordium-smart-contract-engine",
  "concordium-wasm",
+ "concordium_base",
  "hex",
  "ignore",
  "ptree",
@@ -327,7 +327,8 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits 0.2.16",
- "time",
+ "serde 1.0.185",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -349,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "8.0.0"
+version = "8.1.0"
 dependencies = [
  "base64",
  "bs58",
@@ -358,7 +359,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.11.2",
  "hex",
- "num-bigint",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits 0.2.16",
  "rust_decimal",
@@ -369,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -378,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -411,13 +412,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "concordium_base"
+version = "3.1.1"
+dependencies = [
+ "anyhow",
+ "bs58",
+ "byteorder",
+ "chrono",
+ "concordium-contracts-common",
+ "concordium_base_derive",
+ "curve25519-dalek",
+ "derive_more",
+ "ed25519-dalek",
+ "either",
+ "ff",
+ "group",
+ "hex",
+ "itertools",
+ "leb128",
+ "libc",
+ "nom 7.1.3",
+ "num",
+ "num-bigint 0.4.3",
+ "num-traits 0.2.16",
+ "pairing",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
+ "rayon",
+ "rust_decimal",
+ "serde 1.0.185",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.8",
+ "sha3",
+ "subtle",
+ "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "concordium_base_derive"
+version = "1.0.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "config"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
 dependencies = [
  "lazy_static 1.4.0",
- "nom",
+ "nom 5.1.3",
  "rust-ini",
  "serde 1.0.185",
  "serde-hjson",
@@ -448,6 +497,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +550,51 @@ dependencies = [
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+ "serde 1.0.185",
 ]
 
 [[package]]
@@ -523,6 +650,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "rand 0.7.3",
+ "serde 1.0.185",
+ "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
 name = "ed25519-zebra"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +714,31 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "ff"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4530da57967e140ee0b44e0143aa66b5cb42bd9c503dbe316a15d5b0be65713e"
+dependencies = [
+ "byteorder",
+ "ff_derive",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "ff_derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5796e7d62ca01a00ed3a649b0da1ffa1ac8f06bcad40339df09dbdd69a05ba9"
+dependencies = [
+ "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits 0.2.16",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "filetime"
@@ -638,6 +813,17 @@ dependencies = [
  "fnv",
  "log",
  "regex",
+]
+
+[[package]]
+name = "group"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cbdfc48f95bef47e3daf3b9d552a1dde6311e3a5fefa43e16c59f651d56fe5b"
+dependencies = [
+ "ff",
+ "rand 0.7.3",
+ "rand_xorshift",
 ]
 
 [[package]]
@@ -718,6 +904,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "ignore"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,12 +928,33 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde 1.0.185",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde 1.0.185",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -830,6 +1043,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "nom"
 version = "5.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +1066,41 @@ dependencies = [
  "lexical-core",
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits 0.2.16",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.16",
 ]
 
 [[package]]
@@ -852,12 +1115,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+dependencies = [
+ "num-traits 0.2.16",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits 0.2.16",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits 0.2.16",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.4.3",
+ "num-integer",
  "num-traits 0.2.16",
 ]
 
@@ -922,14 +1217,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "pairing"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94c40534479a28199cd5109da27fe2fc4a4728e4fc701d9e9c1bded78f3271e4"
+dependencies = [
+ "byteorder",
+ "ff",
+ "group",
+ "rand_core 0.5.1",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 2.0.0",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1122,6 +1435,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xorshift"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1619,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,6 +1717,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde 1.0.185",
+ "serde_json",
+ "serde_with_macros",
+ "time 0.3.30",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93634eb5f75a2323b16de4748022ac4297f9e76b6dced2be287a099f41b5e788"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,6 +1778,12 @@ dependencies = [
  "digest 0.10.7",
  "keccak",
 ]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "simdutf8"
@@ -1568,6 +1951,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde 1.0.185",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tint"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,7 +2024,7 @@ version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "toml_datetime",
  "winnow",
 ]
@@ -1899,3 +2311,17 @@ name = "zeroize"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -295,8 +295,10 @@ dependencies = [
  "concordium-smart-contract-engine",
  "concordium-wasm",
  "concordium_base",
+ "flate2",
  "hex",
  "ignore",
+ "infer",
  "ptree",
  "rand 0.7.3",
  "reqwest",
@@ -340,6 +342,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -535,6 +548,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -807,6 +829,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1180,6 +1212,15 @@ dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
  "serde 1.0.185",
+]
+
+[[package]]
+name = "infer"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb33622da908807a06f9513c19b3c1ad50fab3e4137d82a78107d502075aa199"
+dependencies = [
+ "cfb",
 ]
 
 [[package]]

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,7 +96,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -91,6 +106,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -240,9 +270,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "camino"
@@ -269,6 +299,7 @@ dependencies = [
  "ignore",
  "ptree",
  "rand 0.7.3",
+ "reqwest",
  "serde 1.0.185",
  "serde_json",
  "sha2 0.10.8",
@@ -480,6 +511,16 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation-sys"
@@ -694,6 +735,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,10 +815,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -803,6 +925,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
 name = "globset"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +952,25 @@ dependencies = [
  "ff",
  "rand 0.7.3",
  "rand_xorshift",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fc23aa11be92976ef4729127f1a74adf36d8436f7816b185d18df956790833"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap 1.9.3",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -875,10 +1022,87 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.4.9",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -908,6 +1132,16 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "ignore"
@@ -947,6 +1181,12 @@ dependencies = [
  "hashbrown 0.14.0",
  "serde 1.0.185",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "itertools"
@@ -1052,10 +1292,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static 1.4.0",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "nom"
@@ -1175,6 +1459,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1490,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1206,6 +1509,50 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac25ee399abb46215765b1cb35bc0212377e58a061560d8b29b024fd0430e7c"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4d56a4c0478783083cfafcc42493dd4a981d41669da64b4572a2a089b51b1d"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -1229,6 +1576,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
 name = "petgraph"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,6 +1590,24 @@ dependencies = [
  "fixedbitset",
  "indexmap 2.0.0",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "powerfmt"
@@ -1531,6 +1902,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde 1.0.185",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1582,6 +1991,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +2034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,6 +2070,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "152e20a0fd0519390fc43ab404663af8a0b794273d2a91d60ad4a39f13ffe110"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1711,6 +2158,18 @@ version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
+ "itoa",
+ "ryu",
+ "serde 1.0.185",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
  "itoa",
  "ryu",
  "serde 1.0.185",
@@ -1801,6 +2260,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1868,6 +2347,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2004,6 +2504,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tokio"
+version = "1.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2 0.5.4",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,16 +2570,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
 name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2054,10 +2640,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "uuid"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vec_map"
@@ -2079,6 +2682,15 @@ checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]
@@ -2125,6 +2737,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,6 +2776,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "web-sys"
+version = "0.3.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "which"
@@ -2277,6 +2911,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d09770118a7eb1ccaf4a594a221334119a44a814fcb0d31c5b85e83e97227a97"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
 ]
 
 [[package]]

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -189,6 +189,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2f7349907b712260e64b0afe2f84692af14a454be26187d9df565c7f69266a"
+dependencies = [
+ "memchr",
+ "serde 1.0.185",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,12 +260,14 @@ dependencies = [
  "concordium-smart-contract-engine",
  "concordium-wasm",
  "hex",
+ "ignore",
  "ptree",
  "rand 0.7.3",
  "serde 1.0.185",
  "serde_json",
  "strsim 0.10.0",
  "structopt",
+ "tar",
  "which",
 ]
 
@@ -530,6 +542,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +601,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
 ]
 
 [[package]]
@@ -654,6 +691,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
+dependencies = [
+ "globset",
+ "lazy_static 1.4.0",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -741,9 +795,9 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "nom"
@@ -1047,13 +1101,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom 0.2.10",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -1160,6 +1223,15 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "seahash"
@@ -1379,6 +1451,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1488,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.29",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1511,6 +1604,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,6 +1713,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1732,15 @@ name = "windows"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]
@@ -1697,6 +1818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -105,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -265,9 +271,11 @@ dependencies = [
  "rand 0.7.3",
  "serde 1.0.185",
  "serde_json",
+ "sha2 0.10.8",
  "strsim 0.10.0",
  "structopt",
  "tar",
+ "tempfile",
  "which",
 ]
 
@@ -332,7 +340,7 @@ checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
  "ansi_term",
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap",
  "unicode-width",
@@ -384,7 +392,7 @@ dependencies = [
  "rand 0.8.5",
  "secp256k1",
  "serde 1.0.185",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "sha3",
  "slab",
  "thiserror",
@@ -540,6 +548,22 @@ name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "filetime"
@@ -769,7 +793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec 0.5.2",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "ryu",
  "static_assertions",
@@ -786,6 +810,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "log"
@@ -1097,7 +1127,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1106,7 +1136,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1216,6 +1246,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1340,9 +1383,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1459,6 +1502,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-concordium"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -37,11 +37,10 @@ path = "../concordium-base/smart-contracts/wasm-transform"
 version = "3.0"
 
 [dependencies.concordium-smart-contract-engine]
-version = "3.0"
+version = "3.1"
 path = "../concordium-base/smart-contracts/wasm-chain-integration/"
 features = ["display-state"]
 
-[dependencies.concordium-contracts-common]
-version = "8.0"
-path = "../concordium-base/smart-contracts/contracts-common/concordium-contracts-common"
-features = ["derive-serde", "std"]
+[dependencies.concordium_base]
+version = "3.1.1"
+path = "../concordium-base/rust-src/concordium_base"

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -43,5 +43,5 @@ features = ["display-state"]
 
 [dependencies.concordium-contracts-common]
 version = "8.0"
-path = "../concordium-base/concordium-contracts-common/concordium-contracts-common"
+path = "../concordium-base/smart-contracts/contracts-common/concordium-contracts-common"
 features = ["derive-serde", "std"]

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -32,6 +32,8 @@ tar = "0.4"
 sha2 = "0.10"
 tempfile = "3.8"
 reqwest = { version = "0.11.22", features = ["blocking"] }
+infer = "0.15"
+flate2 = "1.0"
 
 [dependencies.concordium-wasm]
 path = "../concordium-base/smart-contracts/wasm-transform"

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -27,6 +27,8 @@ strsim = "0.10"
 which = "4.3"
 rand = { version = "=0.7", features = ["small_rng"] }
 cargo_metadata = "0.15"
+ignore = "0.4"
+tar = "0.4"
 
 [dependencies.concordium-wasm]
 path = "../concordium-base/smart-contracts/wasm-transform"

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-concordium"
-version = "3.0.0"
+version = "3.1.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 license-file = "../LICENSE"

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -31,6 +31,7 @@ ignore = "0.4"
 tar = "0.4"
 sha2 = "0.10"
 tempfile = "3.8"
+reqwest = { version = "0.11.22", features = ["blocking"] }
 
 [dependencies.concordium-wasm]
 path = "../concordium-base/smart-contracts/wasm-transform"

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -29,6 +29,8 @@ rand = { version = "=0.7", features = ["small_rng"] }
 cargo_metadata = "0.15"
 ignore = "0.4"
 tar = "0.4"
+sha2 = "0.10"
+tempfile = "3.8"
 
 [dependencies.concordium-wasm]
 path = "../concordium-base/smart-contracts/wasm-transform"

--- a/cargo-concordium/README.md
+++ b/cargo-concordium/README.md
@@ -102,7 +102,8 @@ Information about the sources and the build will be embedded into
   example above)
 - the exact build command executed inside the image
 - optionally the link to the sources if the `--source` flag is provided. If this
-  is not provided the link can be embedded later.
+  is not provided the link can be embedded later. The source link should point
+  either to the `tar` file directly, or to a `gzip`ped version of the file.
 
 ### Publishing the sources
 
@@ -123,11 +124,11 @@ to the metadata.
 
 ### Verifying a build
 
-To verify that a deployed module was built from given sources there is a
-`cargo concordium verify-build` command. This takes a path to the module and
-optionally a path to the source `tar` archive. If the `tar` archive is not
-provided then it will be downloaded from a link embedded in the module, if
-available.
+To verify that a deployed module was built from given sources there is a `cargo
+concordium verify-build` command. This takes a path to the module and optionally
+a path to the source `tar` archive. If the `tar` archive is not provided then it
+will be downloaded from a link embedded in the module, if available. The source
+link may also point to a gzipped `tar` archive.
 
 For example
 ```

--- a/cargo-concordium/README.md
+++ b/cargo-concordium/README.md
@@ -71,6 +71,9 @@ always build the contract in a fixed environment specified as a Docker image.
 The list of available images can be found on
 [DockerHub](https://hub.docker.com/r/concordium/verifiable-sc/)
 
+**Note that the image used to verify a build is part of the chain of trust. When
+verifying a build you must only use images you trust.**
+
 Both `cargo concordium build` and `cargo concordium test` support verifiable
 builds, which can be requested by adding the option `--verifiable` to the build
 command. The value of this option should be a docker image listed above. For example

--- a/cargo-concordium/README.md
+++ b/cargo-concordium/README.md
@@ -62,6 +62,90 @@ or even `opt-level = "z"`.
 
 In some cases using `opt-level=3` actually leads to smaller code sizes, presumably due to more inlining and dead code removal as a result.
 
+## Reproducible and verifiable builds.
+
+A normal build with `cargo concordium build` is generally not reproducible since
+some host information is embedded into the resulting binary. For this reason
+`cargo concordium` supports so-called verifiable or reproducible builds that
+always build the contract in a fixed environment specified as a Docker image.
+The list of available images can be found on
+[DockerHub](https://hub.docker.com/r/concordium/verifiable-sc/)
+
+Both `cargo concordium build` and `cargo concordium test` support verifiable
+builds, which can be requested by adding the option `--verifiable` to the build
+command. The value of this option should be a docker image listed above. For example
+
+```
+cargo concordium build --verifiable concordium/verifable-sc:1.70 -o contract.wasm.v1 -e
+```
+This will build the smart contract, embed the schema (`-e`) and output it to
+`contract.wasm.v1` file. In addition to this `cargo concordium` will also
+produce a file `contract.wasm.v1.tar` that contains the exact sources that were
+used to build the contract.
+
+When constructing the `tar` archive `cargo concordium` will include the contents
+of the package root subject to the following
+- files listed in `.gitignore` are ignored (both `.gitignore` in the package
+  directory and parent directories)
+- the package build directory (typically `target`) will be ignored
+- additionally files listed in any `.ignore` files will be ignored. The format
+  of this file should be the same as a `.gitignore` file.
+
+Information about the sources and the build will be embedded into
+`contract.wasm.v1` file. This information includes
+
+- SHA2-256 hash of the `tar` file
+- the docker image used in the build (`concordium/verifiable-sc:1.70` in the
+  example above)
+- the exact build command executed inside the image
+- optionally the link to the sources if the `--source` flag is provided. If this
+  is not provided the link can be embedded later.
+
+### Publishing the sources
+
+The `tar` archive is meant to be published and its link embedded in the source
+that is put to the chain. Before registering the module on the chain the `tar`
+file should be uploaded somewhere that is accessible via http `GET` request.
+Then the link should be embedded into the `wasm.v1` file using the
+`edit-build-info` command.
+
+```
+cargo concordium edit-build-info --module contract.wasm.v1 --source-link https://domain.com/contract.wasm.v1.tar --verify
+```
+
+The `--verify` flag is optional, and if it is set `cargo concordium` will
+download the contents at the supplied link and verify that it matches the build
+metadata that is already embedded in the module. If it does, the link is added
+to the metadata.
+
+### Verifying a build
+
+To verify that a deployed module was built from given sources there is a
+`cargo concordium verify-build` command. This takes a path to the module and
+optionally a path to the source `tar` archive. If the `tar` archive is not
+provided then it will be downloaded from a link embedded in the module, if
+available.
+
+For example
+```
+cargo concordium verify-build --module contract.wasm.v1
+```
+
+### Printing build information
+
+```
+cargo concordium print-build-info --module contract.wasm.v1
+```
+
+Will print any embedded build information.
+
+### Limitations
+
+- The `Cargo.lock` file must be up to date for reproducible builds.
+- The contract sources must be either available remotely on a package
+  repository such as [crates.io](https://crates.io) or entirely under the
+  package root directory.
+
 ## Locally executing contracts
 
 The following are some example invocations of the `cargo concordium` binary's subcommand `run`.

--- a/cargo-concordium/README.md
+++ b/cargo-concordium/README.md
@@ -78,7 +78,7 @@ command. The value of this option should be a docker image listed above. For exa
 ```
 cargo concordium build --verifiable concordium/verifable-sc:1.70 -o contract.wasm.v1 -e
 ```
-This will build the smart contract, embed the schema (`-e`) and output it to
+This will build the smart contract, embed the schema (`-e`) and output it to a
 `contract.wasm.v1` file. In addition to this `cargo concordium` will also
 produce a file `contract.wasm.v1.tar` that contains the exact sources that were
 used to build the contract.
@@ -88,7 +88,7 @@ of the package root subject to the following
 - files listed in `.gitignore` are ignored (both `.gitignore` in the package
   directory and parent directories)
 - the package build directory (typically `target`) will be ignored
-- additionally files listed in any `.ignore` files will be ignored. The format
+- additional files listed in any `.ignore` files will be ignored. The format
   of this file should be the same as a `.gitignore` file.
 
 Information about the sources and the build will be embedded into

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -137,7 +137,7 @@ fn create_archive(
     let files = ignore::WalkBuilder::new(package_root_path)
         .git_global(false)
         .git_ignore(true)
-        .parents(false)
+        .parents(true)
         .hidden(false)
         .sort_by_file_path(std::cmp::Ord::cmp)
         .build();

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -101,7 +101,7 @@ impl SchemaBuildOptions {
     pub fn embed(self) -> bool { matches!(self, SchemaBuildOptions::BuildAndEmbed) }
 }
 
-/// Build informatio returned by the [`build_contract`] function.
+/// Build information returned by the [`build_contract`] function.
 pub struct BuildInfo {
     /// Size of the module that was built, including custom section.
     pub total_module_len:  usize,

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -409,9 +409,12 @@ pub fn build_contract(
         // The archive will be named after the `--out` parameter, by appending `.tar` to
         // it.
         let tar_filename: PathBuf = {
-            let mut tar_filename = out_filename.clone();
-            tar_filename.as_mut_os_string().push(".tar");
-            tar_filename
+            // Rust 1.70 has as_mut_os_string, but to support older versions we don't use it
+            // here for now, and instead convert from and to OsString to append an
+            // extension.
+            let mut tar_filename = out_filename.clone().into_os_string();
+            tar_filename.push(".tar");
+            tar_filename.into()
         };
         let ContainerBuildOutput {
             output_wasm,

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -131,11 +131,9 @@ fn create_archive(
     omit_files: &[&Path],
 ) -> anyhow::Result<TarArchiveData> {
     let mut tar = tar::Builder::new(Vec::new());
-    // Ignore files that are listed in the local .gitignore, but
-    // not anything that is listed in a global .gitignore.
-    // This is to make the behaviour more local.
+    // Ignore files that are ignored by Git.
     let files = ignore::WalkBuilder::new(package_root_path)
-        .git_global(false)
+        .git_global(true)
         .git_ignore(true)
         .parents(true)
         .hidden(false)

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -323,6 +323,18 @@ pub fn build_contract(
     out: Option<PathBuf>,
     cargo_args: &[String],
 ) -> anyhow::Result<BuildInfo> {
+    // Check immediately if reproducible build is requested that we can execute the
+    // container runtime.
+    if let Some(image) = &image {
+        if let Err(which::Error::CannotFindBinaryPath) = which::which(&container_runtime) {
+            anyhow::bail!(
+                "cargo concordium build --verifiable {image}` requires `{container_runtime}` \
+                 which does not appear to be installed. Either install `{container_runtime}` or \
+                 choose another container runtime by setting `CARGO_CONCORDIUM_CONTAINER_RUNTIME`."
+            );
+        }
+    }
+
     // If the output path is supplied make sure up-front before building anything
     // that it points to a sensible location
     if let Some(out) = &out {

--- a/cargo-concordium/src/context.rs
+++ b/cargo-concordium/src/context.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
-use concordium_contracts_common::{
-    AccountAddress, Address, Amount, ContractAddress, EntrypointName, OwnedEntrypointName,
+use concordium_base::contracts_common::{
+    self, AccountAddress, Address, Amount, ContractAddress, EntrypointName, OwnedEntrypointName,
     OwnedPolicy, Serial, SlotTime,
 };
 use concordium_smart_contract_engine::{v0, v1, ExecResult};
@@ -206,7 +206,7 @@ fn deserialize_policy_bytes_from_json<'de, D: serde::de::Deserializer<'de>>(
         let len = policies.len() as u16;
         len.serial(&mut out).expect("Cannot fail writing to vec.");
         for policy in policies.iter() {
-            let bytes = concordium_contracts_common::to_bytes(policy);
+            let bytes = contracts_common::to_bytes(policy);
             let internal_len = bytes.len() as u16;
             internal_len
                 .serial(&mut out)

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -2154,7 +2154,10 @@ fn print_build_info(utils::VersionedBuildInfo::V0(bi): &utils::VersionedBuildInf
         "    - Build command used: {}",
         bold_style.paint(bi.build_command.join(" "))
     );
-    eprintln!("    - Hash of the archive: {}", bold_style.paint(bi.archive_hash.to_string()));
+    eprintln!(
+        "    - Hash of the archive: {}",
+        bold_style.paint(bi.archive_hash.to_string())
+    );
     if let Some(link) = &bi.source_link {
         eprintln!("    - Link to source code: {}", bold_style.paint(link));
     } else {

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -309,7 +309,7 @@ struct BuildOptions {
         name = "out",
         long = "out",
         short = "o",
-        help = "Writes the resulting module to file at specified location."
+        help = "Write the resulting smart contract module to file to the specified file."
     )]
     out:                 Option<PathBuf>,
     #[structopt(
@@ -323,6 +323,7 @@ struct BuildOptions {
     #[structopt(
         name = "verifiable",
         long = "verifiable",
+        requires = "out",
         short = "r",
         help = "The image to use for a build of a contract that can be verified. If this is not \
                 supplied then the contract will be built in the context of the host, which is \
@@ -668,6 +669,7 @@ fn handle_build(
         total_module_len,
         schema,
         metadata,
+        stored_build_info,
     } = build_contract(
         options.version,
         build_schema,

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -987,6 +987,16 @@ fn handle_build(
         }
     }
     if print_extra_info {
+        if let Some((bi, archived_files)) = stored_build_info {
+            eprintln!("  Embedded build information information:\n",);
+            print_build_info(&bi);
+            eprintln!();
+            eprintln!("    - Archived source files:");
+            for file in archived_files {
+                eprintln!("        - {}", file.display());
+            }
+        }
+
         let size = format!(
             "{}.{:03} kB",
             total_module_len / 1000,
@@ -997,19 +1007,6 @@ fn handle_build(
             success_style.paint("Finished"),
             bold_style.paint(size)
         );
-
-        if let Some((bi, archived_files)) = stored_build_info {
-            eprintln!(
-                "    {} embedding build information:",
-                success_style.paint("Finished")
-            );
-            print_build_info(&bi);
-            eprintln!();
-            eprintln!("    - Archived source files:");
-            for file in archived_files {
-                eprintln!("        - {}", file.display());
-            }
-        }
     }
     Ok(metadata)
 }
@@ -2115,7 +2112,7 @@ fn print_build_info(utils::VersionedBuildInfo::V0(bi): &utils::VersionedBuildInf
     } else {
         eprintln!(
             "{}",
-            WARNING_STYLE.paint("   - No link to source code embedded.")
+            WARNING_STYLE.paint("    - No link to source code embedded.")
         );
     }
 }

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -429,6 +429,12 @@ struct BuildOptions {
     )]
     container_runtime:   String,
     #[structopt(
+        name = "source-link",
+        long = "source-link",
+        help = "If a verifiable build is requested, a source link can be embedded in the module."
+    )]
+    source_link:         Option<String>,
+    #[structopt(
         raw = true,
         help = "Extra arguments passed to `cargo build` when building Wasm module."
     )]
@@ -761,6 +767,7 @@ fn download_file_into(url: &str, out: &mut impl std::io::Write) -> anyhow::Resul
     Ok(pos)
 }
 
+/// Handler for the command to verify a build.
 fn handle_verify(options: VerifyOptions) -> anyhow::Result<()> {
     let module = WasmModule::from_file(&options.source)?;
     let mut skeleton = parse_skeleton(module.source.as_ref())
@@ -811,6 +818,7 @@ fn handle_verify(options: VerifyOptions) -> anyhow::Result<()> {
     }
 }
 
+/// Handler for the command to edit build information in a module.
 fn handle_edit(options: EditOptions) -> anyhow::Result<()> {
     let module = WasmModule::from_file(&options.source)?;
     let mut skeleton = parse_skeleton(module.source.as_ref())
@@ -928,6 +936,7 @@ fn handle_build(
         options.version,
         build_schema,
         options.image,
+        options.source_link,
         options.container_runtime,
         options.out,
         &options.cargo_args,
@@ -2145,7 +2154,7 @@ fn print_build_info(utils::VersionedBuildInfo::V0(bi): &utils::VersionedBuildInf
         "    - Build command used: {}",
         bold_style.paint(bi.build_command.join(" "))
     );
-    eprintln!("    - Hash of the archive: {}", bi.archive_hash);
+    eprintln!("    - Hash of the archive: {}", bold_style.paint(bi.archive_hash.to_string()));
     if let Some(link) = &bi.source_link {
         eprintln!("    - Link to source code: {}", bold_style.paint(link));
     } else {

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -299,7 +299,7 @@ struct VerifyOptions {
         name = "source",
         long = "source",
         help = "Path to the sources. If not present then the sources will be downloaded from an \
-                embedded link."
+                embedded link in the build info."
     )]
     source_path:       Option<PathBuf>,
     #[structopt(name = "module", long = "module", help = "Module to verify.")]
@@ -398,7 +398,7 @@ struct BuildOptions {
         name = "out",
         long = "out",
         short = "o",
-        help = "Write the resulting smart contract module to file to the specified file."
+        help = "Write the resulting smart contract module to the specified file."
     )]
     out:                 Option<PathBuf>,
     #[structopt(

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -783,7 +783,7 @@ fn handle_build(
             bold_style.paint(size)
         );
 
-        if let Some((bi, archived_files)) = stored_build_info {
+        if let Some((utils::VersionedBuildInfo::V0(bi), archived_files)) = stored_build_info {
             eprintln!(
                 "    {} embedding build information:",
                 success_style.paint("Finished")
@@ -793,7 +793,7 @@ fn handle_build(
                 "    - Build command used: {}",
                 bold_style.paint(bi.build_command.join(" "))
             );
-            eprintln!("    - Build command used: {:?}", bi.archive_hash); // TODO
+            eprintln!("    - Hash of the archive: {}", bi.archive_hash);
             if let Some(link) = bi.source_link {
                 eprintln!("    - Link to source code: {}", bold_style.paint(link));
             } else {

--- a/reproducible/Jenkinsfile
+++ b/reproducible/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
                 sh 'echo "${CRED_PSW}" | docker login --username "${CRED_USR}" --password-stdin'
             }
         }
-        stage('push') {
+        stage('check-duplicate') {
             // Check that the tag does not yet exist.
             steps {
                 sh '! docker manifest inspect "${image_name}"'

--- a/reproducible/Jenkinsfile
+++ b/reproducible/Jenkinsfile
@@ -1,0 +1,41 @@
+pipeline {
+    agent { label 'jenkins-worker' }
+    environment {
+        image_name: "concordium/verifiable-sc:${image_tag}"
+    }
+    stages {
+        stage('dockerhub-login') {
+            environment {
+                // Defines 'CRED_USR' and 'CRED_PSW'
+                // (see 'https://www.jenkins.io/doc/book/pipeline/jenkinsfile/#handling-credentials').
+                CRED = credentials('jenkins-dockerhub')
+            }
+            steps {
+                sh 'echo "${CRED_PSW}" | docker login --username "${CRED_USR}" --password-stdin'
+            }
+        }
+        stage('push') {
+            // Check that the tag does not yet exist.
+            steps {
+                sh '! docker manifest inspect "${image_name}"'
+            }
+        }
+        stage('build') {
+            steps {
+                sh '''\
+                    docker build \
+                      -t "${image_name}" \
+                      --build-arg source_image="${source_image_tag}" \
+                      --label source_image="${source_image_tag}" \
+                      .
+                '''
+            }
+        }
+
+        stage('push') {
+            steps {
+                sh 'docker push "${image_name}"'
+            }
+        }
+    }
+}

--- a/reproducible/build.Dockerfile
+++ b/reproducible/build.Dockerfile
@@ -1,5 +1,12 @@
-ARG build_image
-FROM ${build_image} AS build
+# A builder for images for verifiable/reproducible builds.
+# The `source_image` is meant to be a published Rust image, such as rust:1.70.
+#
+# This image only adds a script `run-copy.sh` that is used by cargo-concordium
+# to copy data in and out of the container. The image also adds
+# wasm32-unknown-unknown target.
+
+ARG source_image
+FROM ${source_image} AS build
 
 RUN rustup target add wasm32-unknown-unknown
 

--- a/reproducible/build.Dockerfile
+++ b/reproducible/build.Dockerfile
@@ -3,6 +3,6 @@ FROM ${build_image} AS build
 
 RUN rustup target add wasm32-unknown-unknown
 
-RUN mkdir /build
+RUN mkdir /b
 
 COPY run-copy.sh /run-copy.sh

--- a/reproducible/build.Dockerfile
+++ b/reproducible/build.Dockerfile
@@ -1,0 +1,8 @@
+ARG build_image
+FROM ${build_image} AS build
+
+RUN rustup target add wasm32-unknown-unknown
+
+RUN mkdir /build
+
+COPY run-copy.sh /run-copy.sh

--- a/reproducible/run-copy.sh
+++ b/reproducible/run-copy.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+export FILE=$2
+export ARCHIVE=$1
+
+mkdir /build
+cd /build
+tar xf $ARCHIVE
+shift 2
+$@
+mv $FILE /artifacts/

--- a/reproducible/run-copy.sh
+++ b/reproducible/run-copy.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 # This script is used as an entrypoint by cargo-concordium and the corresponding
-# docker image
+# docker image.
 # The script takes two arguments for itself `archive` and `build_dir` and
-# a script to execute. It then
+# a command to execute. It then
 #
 # - copies the tar archive into the running container
 # - executes the supplied command

--- a/reproducible/run-copy.sh
+++ b/reproducible/run-copy.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+# This script is used as an entrypoint by cargo-concordium and the corresponding
+# docker image
+# The script takes two arguments for itself `archive` and `build_dir` and
+# a script to execute. It then
+#
+# - copies the tar archive into the running container
+# - executes the supplied command
+# - moves a `wasm` file from `build_dir` into /artifacts/out.wasm
+
 set -e
 
 export BUILD_DIR=$2
@@ -9,5 +18,7 @@ mkdir -p /b
 cd /b
 tar xf $ARCHIVE
 shift 2
+# execute the supplied command which consists of everything apart from the first
+# 2 arguments to the `run-copy` script.
 $@
 mv $BUILD_DIR/*.wasm /artifacts/out.wasm

--- a/reproducible/run-copy.sh
+++ b/reproducible/run-copy.sh
@@ -16,7 +16,7 @@ export ARCHIVE=$1
 
 mkdir -p /b
 cd /b
-tar xf $ARCHIVE
+tar --strip-components=1 -xf $ARCHIVE
 shift 2
 # execute the supplied command which consists of everything apart from the first
 # 2 arguments to the `run-copy` script.

--- a/reproducible/run-copy.sh
+++ b/reproducible/run-copy.sh
@@ -5,8 +5,8 @@ set -e
 export FILE=$2
 export ARCHIVE=$1
 
-mkdir /build
-cd /build
+mkdir -p /b
+cd /b
 tar xf $ARCHIVE
 shift 2
 $@

--- a/reproducible/run-copy.sh
+++ b/reproducible/run-copy.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export FILE=$2
+export BUILD_DIR=$2
 export ARCHIVE=$1
 
 mkdir -p /b
@@ -10,4 +10,4 @@ cd /b
 tar xf $ARCHIVE
 shift 2
 $@
-mv $FILE /artifacts/
+mv $BUILD_DIR/*.wasm /artifacts/out.wasm


### PR DESCRIPTION
## Purpose

Add a way to make reproducible/verifiable builds of smart contract modules.

## Changes

- Add a new option to `cargo concordium build` to build a verifiable module.
- Add a docker image builder to create images to run reproducible builds.
- Add `edit-build-info` command for adding URLs to source modules.
- Add a `verify` command for verifying that a module matches the source.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
