### PR TITLE
Prepare for release of VSCode 2.1.0

### DIFF
--- a/vscode-smart-contracts/CHANGELOG.md
+++ b/vscode-smart-contracts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 2.1.0
+
+- Contains `cargo-concordium` version 3.1.4
+
 ## 2.0.0
 
 - Contains `cargo-concordium` version 3.0.0

--- a/vscode-smart-contracts/README.md
+++ b/vscode-smart-contracts/README.md
@@ -53,6 +53,10 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+## 2.1.0
+
+- Contains `cargo-concordium` version 3.1.4
+
 ### 2.0.0
 
 - Contains `cargo-concordium` version 3.0.0.

--- a/vscode-smart-contracts/package-lock.json
+++ b/vscode-smart-contracts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "concordium-smart-contracts",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "concordium-smart-contracts",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "glob": "^8.1.0"

--- a/vscode-smart-contracts/package.json
+++ b/vscode-smart-contracts/package.json
@@ -4,7 +4,7 @@
   "displayName": "Concordium Smart Contracts",
   "icon": "icon.png",
   "description": "Develop and build smart contracts on Concordium",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Concordium/concordium-smart-contract-tools.git",


### PR DESCRIPTION
## Purpose

Prepare a release of the VSCode extension with the newest version of cargo-concordium (3.1.4)
