### PR TITLE
Fix sc frontend read box

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased changes
 
 - Fix error message when specifying input parameter without uploading schema.
+- Fix error when contract calls return BigInts.
 - Fix contract method names in error messages.
 
 ## 3.0.1

--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased changes
 
 - Fix error message when specifying input parameter without uploading schema.
+- Fix contract method names in error messages.
 
 ## 3.0.1
 

--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix error message when specifying input parameter without uploading schema.
 - Fix error when contract calls return BigInts.
 - Fix contract method names in error messages.
+- Give warning when deploying a module that does not have embedded build information.
 
 ## 3.0.1
 

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -9,6 +9,7 @@
     "dependencies": {
         "@concordium/react-components": "^0.4.0",
         "@concordium/web-sdk": "^7.1.0",
+        "json-bigint": "^1.0.0",
         "moment": "^2.29.4",
         "react": "^18.1.0",
         "react-bootstrap": "^2.7.4",
@@ -18,6 +19,7 @@
         "react-switch": "^7.0.0"
     },
     "devDependencies": {
+        "@types/json-bigint": "^1",
         "@types/node": "^18.7.23",
         "@types/react": "^18.0.9",
         "@types/react-dom": "^18.0.5",

--- a/front-end-tools/src/components/DeployComponent.tsx
+++ b/front-end-tools/src/components/DeployComponent.tsx
@@ -56,6 +56,7 @@ export default function DeployComponenet(props: ConnectionProps) {
 
     const [transactionErrorDeploy, setTransactionErrorDeploy] = useState<string | undefined>(undefined);
     const [uploadError, setUploadError] = useState<string | undefined>(undefined);
+    const [isReproducibleBuild, setIsReproducibleBuild] = useState<boolean | undefined>(undefined);
     const [isModuleReferenceAlreadyDeployedStep1, setIsModuleReferenceAlreadyDeployedStep1] = useState(false);
     const [txHashDeploy, setTxHashDeploy] = useState<string | undefined>(undefined);
     const [base64Module, setBase64Module] = useState<string | undefined>(undefined);
@@ -131,7 +132,7 @@ export default function DeployComponenet(props: ConnectionProps) {
                     <Form.Label>Upload Smart Contract Module File (e.g. myContract.wasm.v1)</Form.Label>
                     <Form.Control
                         type="file"
-                        accept=".wasm,.wasm.v0,.wasm.v1"
+                        accept=".wasm,.v0,.v1"
                         {...form.register('file')}
                         onChange={async (e) => {
                             const register = form.register('file');
@@ -220,6 +221,13 @@ export default function DeployComponenet(props: ConnectionProps) {
                                     );
 
                                     setEmbeddedModuleSchemaBase64Init(moduleSchemaBase64Embedded);
+
+                                    // Check if the module was built as a reproducible build.
+                                    const buildInfoSection = WebAssembly.Module.customSections(
+                                        wasmModule,
+                                        'concordium-build-info'
+                                    );
+                                    setIsReproducibleBuild(buildInfoSection.length !== 0);
                                 } else {
                                     setUploadError('Upload module file is undefined');
                                 }
@@ -229,6 +237,14 @@ export default function DeployComponenet(props: ConnectionProps) {
                     <Form.Text />
                 </Form.Group>
                 {uploadError !== undefined && <Alert variant="danger"> Error: {uploadError}. </Alert>}
+                {isReproducibleBuild === false && (
+                    <Alert variant="warning">
+                        Warning: The module does not have embedded build information. It will likely not be possible to
+                        match this module to source code. See the{' '}
+                        <a href="https://docs.rs/crate/cargo-concordium/latest">cargo-concordium documentation</a> for
+                        more information.
+                    </Alert>
+                )}
                 <br />
                 {base64Module && moduleReferenceCalculated && (
                     <>

--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -101,7 +101,7 @@ export default function ReadComponenet(props: ConnectionProps) {
                 setSchemaError('Schema was not uploaded');
                 return;
             }
-            
+
             const readFunctionTemplate = getUpdateContractParameterSchema(
                 toBuffer(schema, 'base64'),
                 ContractName.fromString(smartContractName),

--- a/front-end-tools/src/reading_from_blockchain.ts
+++ b/front-end-tools/src/reading_from_blockchain.ts
@@ -157,19 +157,21 @@ export async function read(
         parameter: param,
     });
 
+    const fullEntryPointName = `${contractName.value}.${entryPoint.value}`;
+
     if (!res || res.tag === 'failure') {
         const rejectReason = JSON.stringify(
             ((res as InvokeContractFailedResult)?.reason as RejectedReceive)?.rejectReason
         );
 
         throw new Error(
-            `RPC call 'invokeContract' on method '${contractName}.${entryPoint}' of contract '${contractIndex}' failed.
+            `RPC call 'invokeContract' on method '${fullEntryPointName}' of contract '${contractIndex}' failed.
             ${rejectReason !== undefined ? `Reject reason: ${rejectReason}` : ''}`
         );
     }
     if (!res.returnValue) {
         throw new Error(
-            `RPC call 'invokeContract' on method '${contractName}.${entryPoint}' of contract '${contractIndex}' returned no return_value`
+            `RPC call 'invokeContract' on method '${fullEntryPointName}' of contract '${contractIndex}' returned no return_value`
         );
     }
 
@@ -190,13 +192,13 @@ export async function read(
         );
     } catch (e) {
         throw new Error(
-            `Deserializing the returnValue from the '${contractName}.${entryPoint}' method of contract '${contractIndex}' failed. Original error: ${e}`
+            `Deserializing the returnValue from the '${fullEntryPointName}' method of contract '${contractIndex}' failed. Original error: ${e}`
         );
     }
 
     if (returnValue === undefined) {
         throw new Error(
-            `Deserializing the returnValue from the '${contractName}.${entryPoint}' method of contract '${contractIndex}' failed.`
+            `Deserializing the returnValue from the '${fullEntryPointName}' method of contract '${contractIndex}' failed.`
         );
     } else {
         return JSONbig.stringify(returnValue);

--- a/front-end-tools/src/reading_from_blockchain.ts
+++ b/front-end-tools/src/reading_from_blockchain.ts
@@ -15,7 +15,7 @@ import {
     Parameter,
     ReturnValue,
 } from '@concordium/web-sdk';
-
+import JSONbig from 'json-bigint';
 import { CONTRACT_SUB_INDEX } from './constants';
 
 /** This function gets the contract info of a smart contract index. */
@@ -175,7 +175,7 @@ export async function read(
 
     if (moduleSchema === undefined) {
         // If no schema is provided return the raw bytes
-        return JSON.stringify(res.returnValue);
+        return JSONbig.stringify(res.returnValue);
     }
 
     let returnValue;
@@ -199,6 +199,6 @@ export async function read(
             `Deserializing the returnValue from the '${contractName}.${entryPoint}' method of contract '${contractIndex}' failed.`
         );
     } else {
-        return JSON.stringify(returnValue);
+        return JSONbig.stringify(returnValue);
     }
 }

--- a/front-end-tools/yarn.lock
+++ b/front-end-tools/yarn.lock
@@ -1342,6 +1342,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/json-bigint@npm:^1":
+  version: 1.0.4
+  resolution: "@types/json-bigint@npm:1.0.4"
+  checksum: bb567bac8d64f541abb3cb716d5c699c460b9aa4a9fc5fc81a3cee9cb57fe8c03914022049dcdadff213972979a5d08267405d55d2ed6aa95d3558f08347008a
+  languageName: node
+  linkType: hard
+
 "@types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
@@ -3625,6 +3632,7 @@ __metadata:
   dependencies:
     "@concordium/react-components": "npm:^0.4.0"
     "@concordium/web-sdk": "npm:^7.1.0"
+    "@types/json-bigint": "npm:^1"
     "@types/node": "npm:^18.7.23"
     "@types/react": "npm:^18.0.9"
     "@types/react-dom": "npm:^18.0.5"
@@ -3640,6 +3648,7 @@ __metadata:
     eslint-plugin-jsx-a11y: "npm:^6.5.1"
     eslint-plugin-react: "npm:^7.29.4"
     eslint-plugin-react-hooks: "npm:^4.4.0"
+    json-bigint: "npm:^1.0.0"
     moment: "npm:^2.29.4"
     prettier: "npm:^3.1.0"
     process: "npm:^0.11.10"


### PR DESCRIPTION
## Purpose

Closes #139.

## Changes

- RPC calls could return BigInts, which cannot be serialized with `JSON.stringify`. This PR uses the package `json-bigint` as a replacement in places where a return value is serialized to address this.
- Contract method names are fixed in error messages.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.