### PR TITLE
front-end-tools check reproducible modules

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix error message when specifying input parameter without uploading schema.
 - Fix contract method names in error messages.
+- Give warning when deploying a module that is not built with the --verifiable flag.
 
 ## 3.0.1
 

--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Fix error message when specifying input parameter without uploading schema.
 - Fix contract method names in error messages.
-- Give warning when deploying a module that is not built with the --verifiable flag.
+- Give warning when deploying a module that does not have embedded build information.
 
 ## 3.0.1
 

--- a/front-end-tools/src/components/DeployComponent.tsx
+++ b/front-end-tools/src/components/DeployComponent.tsx
@@ -223,7 +223,10 @@ export default function DeployComponenet(props: ConnectionProps) {
                                     setEmbeddedModuleSchemaBase64Init(moduleSchemaBase64Embedded);
 
                                     // Check if the module was built as a reproducible build.
-                                    const buildInfoSection = WebAssembly.Module.customSections(wasmModule, 'concordium-build-info');
+                                    const buildInfoSection = WebAssembly.Module.customSections(
+                                        wasmModule,
+                                        'concordium-build-info'
+                                    );
                                     setIsReproducibleBuild(buildInfoSection.length !== 0);
                                 } else {
                                     setUploadError('Upload module file is undefined');
@@ -236,9 +239,10 @@ export default function DeployComponenet(props: ConnectionProps) {
                 {uploadError !== undefined && <Alert variant="danger"> Error: {uploadError}. </Alert>}
                 {isReproducibleBuild === false && (
                     <Alert variant="warning">
-                        Warning: The module was not built as a reproducible build. See the{' '}
-                        <a href="https://docs.rs/crate/cargo-concordium/latest">cargo-concordium documentation</a>{' '}
-                        for more information.
+                        Warning: The module does not have embedded build information. It will likely not be possible to
+                        match this module to source code. See the{' '}
+                        <a href="https://docs.rs/crate/cargo-concordium/latest">cargo-concordium documentation</a> for
+                        more information.
                     </Alert>
                 )}
                 <br />

--- a/front-end-tools/src/components/DeployComponent.tsx
+++ b/front-end-tools/src/components/DeployComponent.tsx
@@ -56,6 +56,7 @@ export default function DeployComponenet(props: ConnectionProps) {
 
     const [transactionErrorDeploy, setTransactionErrorDeploy] = useState<string | undefined>(undefined);
     const [uploadError, setUploadError] = useState<string | undefined>(undefined);
+    const [isReproducibleBuild, setIsReproducibleBuild] = useState<boolean | undefined>(undefined);
     const [isModuleReferenceAlreadyDeployedStep1, setIsModuleReferenceAlreadyDeployedStep1] = useState(false);
     const [txHashDeploy, setTxHashDeploy] = useState<string | undefined>(undefined);
     const [base64Module, setBase64Module] = useState<string | undefined>(undefined);
@@ -131,7 +132,7 @@ export default function DeployComponenet(props: ConnectionProps) {
                     <Form.Label>Upload Smart Contract Module File (e.g. myContract.wasm.v1)</Form.Label>
                     <Form.Control
                         type="file"
-                        accept=".wasm,.wasm.v0,.wasm.v1"
+                        accept=".wasm,.v0,.v1"
                         {...form.register('file')}
                         onChange={async (e) => {
                             const register = form.register('file');
@@ -220,6 +221,10 @@ export default function DeployComponenet(props: ConnectionProps) {
                                     );
 
                                     setEmbeddedModuleSchemaBase64Init(moduleSchemaBase64Embedded);
+
+                                    // Check if the module was built as a reproducible build.
+                                    const buildInfoSection = WebAssembly.Module.customSections(wasmModule, 'concordium-build-info');
+                                    setIsReproducibleBuild(buildInfoSection.length !== 0);
                                 } else {
                                     setUploadError('Upload module file is undefined');
                                 }
@@ -229,6 +234,13 @@ export default function DeployComponenet(props: ConnectionProps) {
                     <Form.Text />
                 </Form.Group>
                 {uploadError !== undefined && <Alert variant="danger"> Error: {uploadError}. </Alert>}
+                {isReproducibleBuild === false && (
+                    <Alert variant="warning">
+                        Warning: The module was not built as a reproducible build. See the{' '}
+                        <a href="https://docs.rs/crate/cargo-concordium/latest">cargo-concordium documentation</a>{' '}
+                        for more information.
+                    </Alert>
+                )}
                 <br />
                 {base64Module && moduleReferenceCalculated && (
                     <>

--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -101,7 +101,7 @@ export default function ReadComponenet(props: ConnectionProps) {
                 setSchemaError('Schema was not uploaded');
                 return;
             }
-            
+
             const readFunctionTemplate = getUpdateContractParameterSchema(
                 toBuffer(schema, 'base64'),
                 ContractName.fromString(smartContractName),


### PR DESCRIPTION
## Purpose

Addresses #128.

## Changes

We now check for the `concordium-build-info` custom section in the module and give a warning if it is not present.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.