### PR TITLE
Support debugging in cargo-concordium.

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## Unreleased changes
 
 - Fix a bug so that a non-zero status code is now returned by `cargo concordium test` if tests fail.
+- Add support for running contracts while collecting debug output. Contracts can
+  be built with debugging support enabled by using the `--allow-debug` flag that
+  is supported both by `cargo concordium build` and `cargo concordium test`.
+
+  When this flag is enabled in tests debug output is emitted at the end of the
+  test. Additionally, when running tests `cargo-concordium` will set
+  `CARGO_CONCORDIUM_TEST_ALLOW_DEBUG` environment variable for all the tests.
 
 ## 3.1.4
 

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "8.1.0"
+version = "8.1.1"
 dependencies = [
  "base64",
  "bs58",
@@ -471,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.1.1"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "bs58",

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -15,7 +15,7 @@ use concordium_base::{
     smart_contracts::{ContractName, ReceiveName, WasmModule},
 };
 use concordium_smart_contract_engine::{
-    utils::{self, WasmVersion, BUILD_INFO_SECTION_NAME},
+    utils::{self, TestResult, WasmVersion, BUILD_INFO_SECTION_NAME},
     v0, v1, ExecResult,
 };
 use concordium_wasm::{
@@ -372,9 +372,10 @@ fn build_in_container<'a>(
 ///
 /// Note that even if a verifiable build is requested the schemas are built on
 /// the host machine.
-pub fn build_contract(
+pub(crate) fn build_contract(
     version: WasmVersion,
     build_schema: SchemaBuildOptions,
+    enable_debug: bool,
     image: Option<String>,
     source_link: Option<String>,
     container_runtime: String,
@@ -586,6 +587,7 @@ pub fn build_contract(
                 ValidationConfig::V1,
                 &v1::ConcordiumAllowedImports {
                     support_upgrade: true,
+                    enable_debug,
                 },
                 &skeleton,
             )
@@ -1125,7 +1127,11 @@ pub(crate) fn build_and_run_integration_tests(
     build_options: BuildOptions,
     test_targets: Vec<String>,
 ) -> anyhow::Result<()> {
-    let cargo_args = &build_options.cargo_args.clone();
+    let cloned_args = build_options.cargo_args.clone();
+    let cargo_args = cloned_args
+        .iter()
+        .map(|s| s.as_str())
+        .chain(std::iter::once("--features=concordium-std/debug"));
 
     // Build the module in the same way as `cargo concordium build`, except that
     // schema information shouldn't be printed.
@@ -1199,7 +1205,11 @@ pub(crate) fn build_and_run_integration_tests(
 ///
 /// The `seed` argument allows for providing the seed to instantiate a random
 /// number generator. If `None` is given, a random seed will be sampled.
-pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyhow::Result<bool> {
+pub fn build_and_run_wasm_test(
+    enable_debug: bool,
+    extra_args: &[String],
+    seed: Option<u64>,
+) -> anyhow::Result<bool> {
     let (metadata, _) = get_crate_metadata(extra_args)?;
 
     let target_dir = format!("{}/concordium", metadata.target_directory);
@@ -1214,7 +1224,11 @@ pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyh
         "--target",
         "wasm32-unknown-unknown",
         "--features",
-        "concordium-std/wasm-test",
+        if enable_debug {
+            "concordium-std/wasm-test,concordium-std/debug"
+        } else {
+            "concordium-std/wasm-test"
+        },
         "--target-dir",
         target_dir.as_str(),
     ];
@@ -1270,9 +1284,13 @@ pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyh
 
     let results = utils::run_module_tests(&wasm, seed_u64)?;
     let mut num_failed = 0;
-    for result in results {
-        let test_name = result.0;
-        match result.1 {
+    for TestResult {
+        test_name,
+        result,
+        debug_events,
+    } in results
+    {
+        match result {
             Some((err, is_randomized)) => {
                 num_failed += 1;
                 eprintln!(
@@ -1295,6 +1313,12 @@ pub fn build_and_run_wasm_test(extra_args: &[String], seed: Option<u64>) -> anyh
             }
             None => {
                 eprintln!("  - {} ... {}", test_name, Color::Green.bold().paint("ok"));
+            }
+        }
+        if enable_debug {
+            eprintln!("    Emitted debug events.");
+            for event in debug_events {
+                eprintln!("    {event}");
             }
         }
     }

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -975,8 +975,11 @@ fn handle_build(
     let build_schema = options.schema_build_options();
     let is_verifiable_build = options.image.is_some();
     let cargo_args = if options.allow_debug {
-        let mut args = options.cargo_args;
+        // prepend the features at the beginning of the options
+        // since the user might have added some options after `--`.
+        let mut args = Vec::with_capacity(options.cargo_args.len() + 1);
         args.push("--features=concordium-std/debug".into());
+        args.extend(options.cargo_args);
         args
     } else {
         options.cargo_args
@@ -1588,7 +1591,7 @@ fn print_debug(trace: DebugTracker) {
         memory_alloc,
         host_call_trace: _,
         emitted_events,
-        next_index: _,
+        ..
     } = trace;
     eprintln!("Debug information recorded during the run.");
     eprintln!("- {operation} interpreter energy spent on Wasm instruction execution.");


### PR DESCRIPTION
## Purpose

Support the new debugging support in both concordium-std and the testing library.

The `cargo concordium run` command will now output any collected debug information if so desired.

`cargo concordium test` additionally supports `--allow-debug` flag, and if this is set it will enable debugging when building contracts, and also output debug output after running the tests.

## Depends on

- [x] https://github.com/Concordium/concordium-base/pull/488
- [x] https://github.com/Concordium/concordium-rust-sdk/pull/147

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
