### PR TITLE
Update rust version to 1.66 in jenkins job for windows

### DIFF
--- a/cargo-concordium/scripts/windows-cargo-concordium.Jenkinsfile
+++ b/cargo-concordium/scripts/windows-cargo-concordium.Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
                     fi   
 
                     # Set rust env
-                    rustup default 1.65-x86_64-pc-windows-gnu
+                    rustup default 1.66-x86_64-pc-windows-gnu
 
                     cd cargo-concordium
 


### PR DESCRIPTION
## Purpose

`cargo-concordium` jenkins build fail on windows, since it is using Rust version 1.65 and the minimum supported is 1.66.