### PR TITLE
Add option to `deriveFromChain` given a module reference when initializing a contract instance

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+- Add option to `deriveFromChain` given a module reference in Step 2.
+
 ## 3.0.2
 
 - Fix error message when specifying input parameter without uploading schema.

--- a/front-end-tools/README.md
+++ b/front-end-tools/README.md
@@ -3,9 +3,15 @@
 The front end contains useful functionalities for smart contract developers:
 
 - Upload and deploy a smart contract module to chain.
-- Initialize a smart contract module on chain.
+- Initialize a smart contract instance on chain.
+- Invoke a smart contract on chain (reading from chain).
+- Update a smart contract on chain (writing to chain).
 
 Only the browser wallet is supported in the first version (no support for mobile wallets).
+
+## Hosted front end
+
+[Hosted front end link](https://sctools.mainnet.concordium.software/)
 
 ## Prerequisites
 
@@ -30,13 +36,13 @@ To start the front end locally, do the following:
 
 -   Run `yarn build` in this folder.
 -   Run `yarn start` in this folder.
--   Open URL logged in console (typically http://127.0.0.1:8080).
+-   Open URL logged in console (typically http://127.0.0.1:5173).
 
 To have hot-reload (useful for development), do the following instead:
 
 -   Run `yarn watch` in this folder in a terminal.
 -   Run `yarn start` in this folder in another terminal.
--   Open URL logged in console (typically http://127.0.0.1:8080).
+-   Open URL logged in console (typically http://127.0.0.1:5173).
 
 ## Using yarn (on Unix/macOS systems)
 

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "front-end-tools",
     "packageManager": "yarn@4.0.2",
-    "version": "3.0.2",
+    "version": "3.1.0",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -153,7 +153,7 @@ export default function Main(props: ConnectionProps) {
                                 contracts={contracts}
                                 moduleReferenceDeployed={moduleReferenceDeployed}
                                 moduleReferenceCalculated={moduleReferenceCalculated}
-                                embeddedModuleSchemaBase64={embeddedModuleSchemaBase64Init}
+                                embeddedModuleSchemaBase64FromStep1={embeddedModuleSchemaBase64Init}
                             />
 
                             <ReadComponent connection={connection} account={account} client={client} />

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -11,6 +11,7 @@ import {
 } from '@concordium/react-components';
 
 import { Alert } from 'react-bootstrap';
+import { ModuleReference } from '@concordium/web-sdk';
 import DeployComponent from './components/DeployComponent';
 import ReadComponent from './components/ReadComponent';
 import UpdateComponent from './components/UpdateComponent';
@@ -48,8 +49,10 @@ export default function Main(props: ConnectionProps) {
     const [accountBalance, setAccountBalance] = useState<string | undefined>(undefined);
 
     // Shared state between deploy step and init step
-    const [moduleReferenceCalculated, setModuleReferenceCalculated] = useState<string | undefined>(undefined);
-    const [moduleReferenceDeployed, setModuleReferenceDeployed] = useState<string | undefined>(undefined);
+    const [moduleReferenceCalculated, setModuleReferenceCalculated] = useState<ModuleReference.Type | undefined>(
+        undefined
+    );
+    const [moduleReferenceDeployed, setModuleReferenceDeployed] = useState<ModuleReference.Type | undefined>(undefined);
     const [contracts, setContracts] = useState<string[]>([]);
     const [embeddedModuleSchemaBase64Init, setEmbeddedModuleSchemaBase64Init] = useState<string | undefined>(undefined);
 

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -9,9 +9,9 @@ import {
     MAINNET,
     useWalletConnectorSelector,
 } from '@concordium/react-components';
+import { ModuleReference } from '@concordium/web-sdk';
 
 import { Alert } from 'react-bootstrap';
-import { ModuleReference } from '@concordium/web-sdk';
 import DeployComponent from './components/DeployComponent';
 import ReadComponent from './components/ReadComponent';
 import UpdateComponent from './components/UpdateComponent';

--- a/front-end-tools/src/Main.tsx
+++ b/front-end-tools/src/Main.tsx
@@ -52,9 +52,6 @@ export default function Main(props: ConnectionProps) {
     const [moduleReferenceCalculated, setModuleReferenceCalculated] = useState<ModuleReference.Type | undefined>(
         undefined
     );
-    const [moduleReferenceDeployed, setModuleReferenceDeployed] = useState<ModuleReference.Type | undefined>(undefined);
-    const [contracts, setContracts] = useState<string[]>([]);
-    const [embeddedModuleSchemaBase64Init, setEmbeddedModuleSchemaBase64Init] = useState<string | undefined>(undefined);
 
     // Refresh accountInfo periodically.
     // eslint-disable-next-line consistent-return
@@ -138,11 +135,8 @@ export default function Main(props: ConnectionProps) {
                                 connection={connection}
                                 account={account}
                                 client={client}
-                                setContracts={setContracts}
                                 moduleReferenceCalculated={moduleReferenceCalculated}
-                                setModuleReferenceDeployed={setModuleReferenceDeployed}
                                 setModuleReferenceCalculated={setModuleReferenceCalculated}
-                                setEmbeddedModuleSchemaBase64Init={setEmbeddedModuleSchemaBase64Init}
                             />
 
                             <InitComponent
@@ -150,10 +144,7 @@ export default function Main(props: ConnectionProps) {
                                 connection={connection}
                                 account={account}
                                 client={client}
-                                contracts={contracts}
-                                moduleReferenceDeployed={moduleReferenceDeployed}
                                 moduleReferenceCalculated={moduleReferenceCalculated}
-                                embeddedModuleSchemaBase64FromStep1={embeddedModuleSchemaBase64Init}
                             />
 
                             <ReadComponent connection={connection} account={account} client={client} />

--- a/front-end-tools/src/components/DeployComponent.tsx
+++ b/front-end-tools/src/components/DeployComponent.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Alert, Button, Form } from 'react-bootstrap';
-import { Buffer } from 'buffer';
 
 import { WalletConnection } from '@concordium/react-components';
 import {
@@ -143,7 +142,7 @@ export default function DeployComponenet(props: ConnectionProps) {
 
                                 setBase64Module(module);
                                 setModuleReferenceCalculated(
-                                    ModuleReference.fromBuffer(Buffer.from(sha256([new Uint8Array(arrayBuffer)])))
+                                    ModuleReference.fromBuffer(sha256([new Uint8Array(arrayBuffer)]))
                                 );
 
                                 // Concordium's tooling create versioned modules e.g. `.wasm.v1` now.

--- a/front-end-tools/src/components/DeployComponent.tsx
+++ b/front-end-tools/src/components/DeployComponent.tsx
@@ -162,9 +162,7 @@ export default function DeployComponenet(props: ConnectionProps) {
 
                                 setBase64Module(module);
                                 setModuleReferenceCalculated(
-                                    ModuleReference.fromBuffer(
-                                        Buffer.from(sha256([new Uint8Array(arrayBuffer)]))
-                                    )
+                                    ModuleReference.fromBuffer(Buffer.from(sha256([new Uint8Array(arrayBuffer)])))
                                 );
 
                                 // Concordium's tooling create versioned modules e.g. `.wasm.v1` now.

--- a/front-end-tools/src/components/DeployComponent.tsx
+++ b/front-end-tools/src/components/DeployComponent.tsx
@@ -27,9 +27,9 @@ interface ConnectionProps {
     isTestnet: boolean;
     setContracts: (contracts: string[]) => void;
     setEmbeddedModuleSchemaBase64Init: (embeddedModuleSchemaBase64Init: string) => void;
-    setModuleReferenceDeployed: (moduleReferenceDeployed: string | undefined) => void;
-    setModuleReferenceCalculated: (moduleReferenceCalculated: string) => void;
-    moduleReferenceCalculated: string | undefined;
+    setModuleReferenceDeployed: (moduleReferenceDeployed: ModuleReference.Type | undefined) => void;
+    setModuleReferenceCalculated: (moduleReferenceCalculated: ModuleReference.Type) => void;
+    moduleReferenceCalculated: ModuleReference.Type | undefined;
 }
 
 /**
@@ -76,7 +76,9 @@ export default function DeployComponenet(props: ConnectionProps) {
                                 report.outcome.summary.transactionType === TransactionKindString.DeployModule
                             ) {
                                 setTransactionOutcome('Success');
-                                setModuleReferenceDeployed(report.outcome.summary.moduleDeployed.contents);
+                                setModuleReferenceDeployed(
+                                    ModuleReference.fromHexString(report.outcome.summary.moduleDeployed.contents)
+                                );
                                 clearInterval(interval);
                             } else {
                                 setTransactionOutcome('Fail');
@@ -97,7 +99,7 @@ export default function DeployComponenet(props: ConnectionProps) {
     useEffect(() => {
         if (connection && client && moduleReferenceCalculated) {
             client
-                .getModuleSource(ModuleReference.fromHexString(moduleReferenceCalculated))
+                .getModuleSource(moduleReferenceCalculated)
                 .then((value) => {
                     if (value === undefined) {
                         setIsModuleReferenceAlreadyDeployedStep1(false);
@@ -160,7 +162,9 @@ export default function DeployComponenet(props: ConnectionProps) {
 
                                 setBase64Module(module);
                                 setModuleReferenceCalculated(
-                                    Buffer.from(sha256([new Uint8Array(arrayBuffer)])).toString('hex')
+                                    ModuleReference.fromBuffer(
+                                        Buffer.from(sha256([new Uint8Array(arrayBuffer)]))
+                                    )
                                 );
 
                                 // Concordium's tooling create versioned modules e.g. `.wasm.v1` now.
@@ -250,7 +254,7 @@ export default function DeployComponenet(props: ConnectionProps) {
                     <>
                         <div className="actionResultBox">
                             Calculated module reference:
-                            <div>{moduleReferenceCalculated}</div>
+                            <div>{moduleReferenceCalculated.moduleRef}</div>
                         </div>
                         <div className="actionResultBox">
                             Module in base64:

--- a/front-end-tools/src/components/InitComponent.tsx
+++ b/front-end-tools/src/components/InitComponent.tsx
@@ -703,8 +703,8 @@ export default function InitComponent(props: ConnectionProps) {
                 )}
                 {shouldWarnNoEmbeddedSchema && (
                     <Alert variant="warning">
-                        Warning: No schema was embedded in module. It is unknown if contract expects an input parameter.
-                        No parameter schemas will be displayed
+                        Warning: No schema was embedded in the module deployed on chain. It is unknown if contract
+                        expects an input parameter. No parameter schemas will be displayed
                     </Alert>
                 )}
                 {shouldWarnInputParameterInSchemaIgnored && (

--- a/front-end-tools/src/components/InitComponent.tsx
+++ b/front-end-tools/src/components/InitComponent.tsx
@@ -162,7 +162,7 @@ export default function InitComponent(props: ConnectionProps) {
         if (
             moduleReference !== undefined &&
             moduleReferenceCalculated !== undefined &&
-            moduleReferenceCalculated.moduleRef !== moduleReference.moduleRef
+            !ModuleReference.equals(moduleReferenceCalculated, moduleReference)
         ) {
             return true;
         }

--- a/front-end-tools/src/components/InitComponent.tsx
+++ b/front-end-tools/src/components/InitComponent.tsx
@@ -56,7 +56,7 @@ export default function InitComponent(props: ConnectionProps) {
 
     type FormType = {
         cCDAmount: number;
-        deriveFromModuleRefernce: string | undefined;
+        deriveFromModuleReference: string | undefined;
         file: FileList | undefined;
         hasInputParameter: boolean;
         inputParameter: string | undefined;
@@ -69,11 +69,11 @@ export default function InitComponent(props: ConnectionProps) {
 
     const form = useForm<FormType>({ mode: 'all' });
 
-    const [deriveFromModuleRefernce, hasInputParameter, inputParameterType, isPayable, smartContractName, file] =
+    const [deriveFromModuleReference, hasInputParameter, inputParameterType, isPayable, smartContractName, file] =
         useWatch({
             control: form.control,
             name: [
-                'deriveFromModuleRefernce',
+                'deriveFromModuleReference',
                 'hasInputParameter',
                 'inputParameterType',
                 'isPayable',
@@ -145,11 +145,7 @@ export default function InitComponent(props: ConnectionProps) {
             client
                 .getModuleSource(moduleReference)
                 .then((value) => {
-                    if (value === undefined) {
-                        setIsModuleReferenceAlreadyDeployed(false);
-                    } else {
-                        setIsModuleReferenceAlreadyDeployed(true);
-                    }
+                    setIsModuleReferenceAlreadyDeployed(value !== undefined);
                 })
                 .catch(() => {
                     setIsModuleReferenceAlreadyDeployed(false);
@@ -175,12 +171,7 @@ export default function InitComponent(props: ConnectionProps) {
         return false;
     }, [inputParameterTemplate, hasInputParameter]);
 
-    const shouldWarnNoEmbeddedSchema = useMemo(() => {
-        if (schema?.length === 0) {
-            return true;
-        }
-        return false;
-    }, [schema]);
+    const shouldWarnNoEmbeddedSchema = useMemo(() => schema?.length === 0, [schema]);
 
     useEffect(() => {
         setSchemaError(undefined);
@@ -194,24 +185,24 @@ export default function InitComponent(props: ConnectionProps) {
             }
 
             if (schema) {
-                const inputParamterTypeSchemaBuffer = getInitContractParameterSchema(
+                const inputParameterTypeSchemaBuffer = getInitContractParameterSchema(
                     toBuffer(schema, 'base64'),
                     ContractName.fromString(smartContractName),
                     2
                 );
 
-                initTemplate = displayTypeSchemaTemplate(inputParamterTypeSchemaBuffer);
+                initTemplate = displayTypeSchemaTemplate(inputParameterTypeSchemaBuffer);
 
                 setInputParameterTemplate(initTemplate);
             }
         } catch (e) {
-            if (deriveFromModuleRefernce === DO_NOT_DERIVE.value) {
+            if (deriveFromModuleReference === DO_NOT_DERIVE.value) {
                 setSchemaError(
-                    `Could not get schema from uploaded schema. Uncheck "Has Input Paramter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
+                    `Could not get schema from uploaded schema. Uncheck "Has Input Parameter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
                 );
             } else {
                 setSchemaError(
-                    `Could not get embedded schema from the module. Select "${DO_NOT_DERIVE.label}" to manually upload a schema or uncheck "Has Input Paramter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
+                    `Could not get embedded schema from the module. Select "${DO_NOT_DERIVE.label}" to manually upload a schema or uncheck "Has Input Parameter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
                 );
             }
         }
@@ -290,12 +281,12 @@ export default function InitComponent(props: ConnectionProps) {
             AccountAddress.fromBase58(account),
             isModuleReferenceAlreadyDeployed,
             moduleReference,
-            data.inputParameter,
             data.smartContractName ? ContractName.fromString(data.smartContractName) : undefined,
             data.hasInputParameter,
-            data.deriveFromModuleRefernce,
-            schema,
+            data.inputParameter,
             data.inputParameterType,
+            schema,
+            data.deriveFromModuleReference,
             Energy.create(data.maxExecutionEnergy),
             CcdAmount.fromMicroCcd(data.cCDAmount ?? 0)
         );
@@ -306,12 +297,12 @@ export default function InitComponent(props: ConnectionProps) {
         <Box header="Step 2: Initialize Smart Contract">
             <Form onSubmit={form.handleSubmit(onSubmit)}>
                 <Form.Group className="justify-content-center">
-                    <Form.Label>DeriveFromModuleRefernce</Form.Label>
+                    <Form.Label>DeriveFromModuleReference</Form.Label>
                     <Select
-                        {...form.register('deriveFromModuleRefernce', { required: true })}
+                        {...form.register('deriveFromModuleReference', { required: true })}
                         options={OPTIONS_DERIVE_FROM_MODULE_REFERENCE}
                         onChange={async (e) => {
-                            form.setValue('deriveFromModuleRefernce', e?.value);
+                            form.setValue('deriveFromModuleReference', e?.value);
 
                             setModuleReferenceError(undefined);
                             setModuleReferenceLengthError(undefined);
@@ -320,7 +311,7 @@ export default function InitComponent(props: ConnectionProps) {
                             form.setValue('file', undefined);
                             setDisplayContracts([]);
 
-                            const selectValue = form.getValues('deriveFromModuleRefernce');
+                            const selectValue = form.getValues('deriveFromModuleReference');
 
                             if (selectValue === DERIVE_FROM_STEP_1.value) {
                                 form.clearErrors('moduleReferenceString');
@@ -348,7 +339,7 @@ export default function InitComponent(props: ConnectionProps) {
                             }
                         }}
                     />
-                    {deriveFromModuleRefernce === DERIVE_FROM_STEP_1.value && (
+                    {deriveFromModuleReference === DERIVE_FROM_STEP_1.value && (
                         <>
                             <br />
                             <Alert variant="info">
@@ -373,7 +364,7 @@ export default function InitComponent(props: ConnectionProps) {
                             <br />
                         </>
                     )}
-                    {deriveFromModuleRefernce === DERIVE_FROM_CHAIN.value && (
+                    {deriveFromModuleReference === DERIVE_FROM_CHAIN.value && (
                         <>
                             <br />
                             <Alert variant="info">
@@ -408,7 +399,7 @@ export default function InitComponent(props: ConnectionProps) {
                         <Form.Label> Module Reference</Form.Label>
                         <Form.Control
                             defaultValue={MODULE_REFERENCE_PLACEHOLDER}
-                            disabled={deriveFromModuleRefernce === DERIVE_FROM_STEP_1.value}
+                            disabled={deriveFromModuleReference === DERIVE_FROM_STEP_1.value}
                             {...form.register('moduleReferenceString', {
                                 required: true,
                                 validate: validateModuleReference,
@@ -423,7 +414,7 @@ export default function InitComponent(props: ConnectionProps) {
                         <Form.Text />
                     </Form.Group>
 
-                    {deriveFromModuleRefernce !== DO_NOT_DERIVE.value && displayContracts.length > 0 ? (
+                    {deriveFromModuleReference !== DO_NOT_DERIVE.value && displayContracts.length > 0 ? (
                         <Form.Group className="col-md-4 mb-3">
                             <Form.Label>Smart Contract Name</Form.Label>
 
@@ -536,7 +527,7 @@ export default function InitComponent(props: ConnectionProps) {
 
                 {hasInputParameter && (
                     <div className="box">
-                        {deriveFromModuleRefernce === DO_NOT_DERIVE.value && (
+                        {deriveFromModuleReference === DO_NOT_DERIVE.value && (
                             <Form.Group className="mb-3">
                                 <Form.Label>Upload Smart Contract Module Schema File (e.g. schema.bin)</Form.Label>
                                 <Form.Control
@@ -573,7 +564,7 @@ export default function InitComponent(props: ConnectionProps) {
                                 <Form.Text />
                             </Form.Group>
                         )}
-                        {deriveFromModuleRefernce === DO_NOT_DERIVE.value && schema && (
+                        {deriveFromModuleReference === DO_NOT_DERIVE.value && schema && (
                             <div className="actionResultBox">
                                 Schema in base64:
                                 <div>{schema.toString().slice(0, 30)} ...</div>

--- a/front-end-tools/src/components/InitComponent.tsx
+++ b/front-end-tools/src/components/InitComponent.tsx
@@ -683,11 +683,6 @@ export default function InitComponent(props: ConnectionProps) {
                     </div>
                 )}
                 <br />
-                <Button variant="primary" type="submit">
-                    Initialize Smart Contract
-                </Button>
-                <br />
-                <br />
                 {!isModuleReferenceAlreadyDeployed && (
                     <Alert variant="warning">Warning: Module reference does not exist on chain.</Alert>
                 )}
@@ -706,6 +701,17 @@ export default function InitComponent(props: ConnectionProps) {
                         Warning: Input parameter schema found but &quot;Has Input Parameter&quot; checkbox is unchecked.
                     </Alert>
                 )}
+                {isModuleReferenceAlreadyDeployedError !== undefined && (
+                    <Alert variant="danger"> Error: {isModuleReferenceAlreadyDeployedError}.</Alert>
+                )}
+                <br />
+
+                <Button variant="primary" type="submit">
+                    Initialize Smart Contract
+                </Button>
+
+                <br />
+                <br />
                 {!txHash && transactionError && <Alert variant="danger">Error: {transactionError}.</Alert>}
                 {txHash && (
                     <TxHashLink
@@ -717,9 +723,6 @@ export default function InitComponent(props: ConnectionProps) {
                 <br />
                 {smartContractIndexError !== undefined && (
                     <Alert variant="danger"> Error: {smartContractIndexError}.</Alert>
-                )}
-                {isModuleReferenceAlreadyDeployedError !== undefined && (
-                    <Alert variant="danger"> Error: {isModuleReferenceAlreadyDeployedError}.</Alert>
                 )}
                 {smartContractIndex !== undefined && (
                     <div className="actionResultBox">

--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -99,7 +99,7 @@ export default function ReadComponenet(props: ConnectionProps) {
             const schema = deriveContractInfo ? embeddedModuleSchemaBase64 : uploadedModuleSchemaBase64;
             if (schema === undefined) {
                 setSchemaError(
-                    'Schema was not uploaded or not embedded into the module. Uncheck the "Derive From Smart Contract Index" checkbox to manually upload a schema or uncheck "Has Input Paramter" checkbox if this entrypoint has no input parameter'
+                    'Schema was not uploaded or not embedded into the module. Uncheck the "Derive From Smart Contract Index" checkbox to manually upload a schema or uncheck "Has Input Parameter" checkbox if this entrypoint has no input parameter'
                 );
                 return;
             }
@@ -116,11 +116,11 @@ export default function ReadComponenet(props: ConnectionProps) {
         } catch (e) {
             if (deriveContractInfo) {
                 setSchemaError(
-                    `Could not derive the embedded schema from the smart contract index. Uncheck "Derive From Smart Contract Index" checkbox to manually upload a schema or uncheck "Has Input Paramter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
+                    `Could not derive the embedded schema from the smart contract index. Uncheck "Derive From Smart Contract Index" checkbox to manually upload a schema or uncheck "Has Input Parameter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
                 );
             } else {
                 setSchemaError(
-                    `Could not get schema from uploaded schema. Uncheck "Has Input Paramter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
+                    `Could not get schema from uploaded schema. Uncheck "Has Input Parameter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
                 );
             }
         }
@@ -147,10 +147,10 @@ export default function ReadComponenet(props: ConnectionProps) {
             ContractName.fromString(data.smartContractName),
             BigInt(data.smartContractIndex),
             data.entryPointName ? EntrypointName.fromString(data.entryPointName) : undefined,
-            schema,
+            data.hasInputParameter,
             data.inputParameter,
             data.inputParameterType,
-            data.hasInputParameter,
+            schema,
             data.deriveFromSmartContractIndex
         );
 

--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -516,12 +516,6 @@ export default function ReadComponenet(props: ConnectionProps) {
                 )}
 
                 <br />
-
-                <Button variant="primary" type="submit">
-                    Read Smart Contract
-                </Button>
-                <br />
-                <br />
                 {(deriveContractInfo ? embeddedModuleSchemaBase64 : uploadedModuleSchemaBase64) === undefined && (
                     <Alert variant="warning">
                         {' '}
@@ -534,6 +528,14 @@ export default function ReadComponenet(props: ConnectionProps) {
                         Warning: Input parameter schema found but &quot;Has Input Parameter&quot; checkbox is unchecked.{' '}
                     </Alert>
                 )}
+                <br />
+
+                <Button variant="primary" type="submit">
+                    Read Smart Contract
+                </Button>
+
+                <br />
+                <br />
                 {error && <Alert variant="danger"> Error: {error}. </Alert>}
                 {returnValue && (
                     <div className="actionResultBox">

--- a/front-end-tools/src/components/UpdateComponent.tsx
+++ b/front-end-tools/src/components/UpdateComponent.tsx
@@ -594,18 +594,20 @@ export default function UpdateComponenet(props: ConnectionProps) {
                 )}
 
                 <br />
-
-                <Button variant="primary" type="submit">
-                    Update Smart Contract
-                </Button>
-                <br />
-                <br />
                 {shouldWarnInputParameterInSchemaIgnored && (
                     <Alert variant="warning">
                         {' '}
                         Warning: Input parameter schema found but &quot;Has Input Parameter&quot; checkbox is unchecked.
                     </Alert>
                 )}
+                <br />
+
+                <Button variant="primary" type="submit">
+                    Update Smart Contract
+                </Button>
+
+                <br />
+                <br />
                 {!txHashUpdate && transactionErrorUpdate && (
                     <Alert variant="danger"> Error: {transactionErrorUpdate}. </Alert>
                 )}

--- a/front-end-tools/src/components/UpdateComponent.tsx
+++ b/front-end-tools/src/components/UpdateComponent.tsx
@@ -144,7 +144,7 @@ export default function UpdateComponenet(props: ConnectionProps) {
             const schema = deriveContractInfo ? embeddedModuleSchemaBase64 : uploadedModuleSchemaBase64;
             if (schema === undefined) {
                 setSchemaError(
-                    'Schema was not uploaded or not embedded into the module. Uncheck the "Derive From Smart Contract Index" checkbox to manually upload a schema or uncheck "Has Input Paramter" checkbox if this entrypoint has no input parameter'
+                    'Schema was not uploaded or not embedded into the module. Uncheck the "Derive From Smart Contract Index" checkbox to manually upload a schema or uncheck "Has Input Parameter" checkbox if this entrypoint has no input parameter'
                 );
                 return;
             }
@@ -161,11 +161,11 @@ export default function UpdateComponenet(props: ConnectionProps) {
         } catch (e) {
             if (deriveContractInfo) {
                 setSchemaError(
-                    `Could not derive the embedded schema from the smart contract index. Uncheck "Derive From Smart Contract Index" checkbox to manually upload a schema or uncheck "Has Input Paramter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
+                    `Could not derive the embedded schema from the smart contract index. Uncheck "Derive From Smart Contract Index" checkbox to manually upload a schema or uncheck "Has Input Parameter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
                 );
             } else {
                 setSchemaError(
-                    `Could not get schema from uploaded schema. Uncheck "Has Input Paramter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
+                    `Could not get schema from uploaded schema. Uncheck "Has Input Parameter" checkbox if this entrypoint has no input parameter. Original error: ${e}`
                 );
             }
         }
@@ -187,17 +187,16 @@ export default function UpdateComponenet(props: ConnectionProps) {
         const schema = deriveContractInfo ? embeddedModuleSchemaBase64 : uploadedModuleSchemaBase64;
 
         // Send update transaction
-
         const tx = update(
             connection,
             AccountAddress.fromBase58(account),
-            data.inputParameter,
             ContractName.fromString(data.smartContractName),
             data.entryPointName ? EntrypointName.fromString(data.entryPointName) : undefined,
-            data.hasInputParameter,
             data.deriveFromSmartContractIndex,
-            schema,
+            data.hasInputParameter,
+            data.inputParameter,
             data.inputParameterType,
+            schema,
             Energy.create(data.maxExecutionEnergy),
             BigInt(data.smartContractIndex),
             CcdAmount.fromMicroCcd(data.cCDAmount ?? 0)

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -34,3 +34,6 @@ export const CONTRACT_SUB_INDEX = 0n;
 
 // Characters of a hex string.
 export const hexRegex = /^[0-9a-fA-F]+$/;
+
+// Module reference displayed as placeholder in the input field.
+export const MODULE_REFERENCE_PLACEHOLDER = '91225f9538ac2903466cc4ab07b6eb607a2cd349549f357dfdf4e6042dde0693';

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -31,6 +31,3 @@ export const INPUT_PARAMETER_TYPES_OPTIONS = [
 
 // The subindex of all smart contracts.
 export const CONTRACT_SUB_INDEX = 0n;
-
-// Regular expression of a valid module reference which has to be a hex string `[0-9A-Fa-f]` of length 64.
-export const REG_MODULE_REF = /^[0-9A-Fa-f]{64}$/;

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -38,8 +38,8 @@ export const INPUT_PARAMETER_TYPES_OPTIONS = [
 // The subindex of all smart contracts.
 export const CONTRACT_SUB_INDEX = 0n;
 
-// Characters of a hex string.
-export const hexRegex = /^[0-9a-fA-F]+$/;
+// Regular expression of a valid module reference which has to be a hex string `[0-9A-Fa-f]` of length 64.
+export const REG_MODULE_REF = /^[0-9A-Fa-f]{64}$/;
 
 // Module reference displayed as placeholder in the input field.
 export const MODULE_REFERENCE_PLACEHOLDER = '91225f9538ac2903466cc4ab07b6eb607a2cd349549f357dfdf4e6042dde0693';

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -21,12 +21,18 @@ export const EXAMPLE_JSON_OBJECT = {
 // or does not want to use the embedded schema (meaning if the checkbox "Use module from step 1" is unchecked).
 export const EXAMPLE_ARRAYS = 'Examples: \n\n[1,2,3] or \n\n["abc","def"] or \n\n[{"myFieldKey":"myFieldValue"}]';
 
-// The input parameter can have one of these type options.
+// Available options for the input parameter type in step 2.
+export const INPUT_PARAMETER_TYPE_NUMBER = { label: 'number', value: 'number' };
+export const INPUT_PARAMETER_TYPE_STRING = { label: 'string', value: 'string' };
+export const INPUT_PARAMETER_TYPE_OBJECT = { label: 'object', value: 'object' };
+export const INPUT_PARAMETER_TYPE_ARRAY = { label: 'array', value: 'array' };
+
+// All available options for the input parameter type in step 2.
 export const INPUT_PARAMETER_TYPES_OPTIONS = [
-    { label: 'number', value: 'number' },
-    { label: 'string', value: 'string' },
-    { label: 'object', value: 'object' },
-    { label: 'array', value: 'array' },
+    INPUT_PARAMETER_TYPE_NUMBER,
+    INPUT_PARAMETER_TYPE_STRING,
+    INPUT_PARAMETER_TYPE_OBJECT,
+    INPUT_PARAMETER_TYPE_ARRAY,
 ];
 
 // The subindex of all smart contracts.
@@ -37,3 +43,11 @@ export const hexRegex = /^[0-9a-fA-F]+$/;
 
 // Module reference displayed as placeholder in the input field.
 export const MODULE_REFERENCE_PLACEHOLDER = '91225f9538ac2903466cc4ab07b6eb607a2cd349549f357dfdf4e6042dde0693';
+
+// Available options to select in step 2 for deriving values from the module references.
+export const DO_NOT_DERIVE = { value: "Don't derive", label: "Don't derive" };
+export const DERIVE_FROM_STEP_1 = { value: 'Derive from step 1', label: 'Derive from step 1' };
+export const DERIVE_FROM_CHAIN = { value: 'Derive from chain', label: 'Derive from chain' };
+
+// All available options to select in step 2 for deriving values from the module references.
+export const OPTIONS_DERIVE_FROM_MODULE_REFERENCE = [DO_NOT_DERIVE, DERIVE_FROM_STEP_1, DERIVE_FROM_CHAIN];

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -31,3 +31,6 @@ export const INPUT_PARAMETER_TYPES_OPTIONS = [
 
 // The subindex of all smart contracts.
 export const CONTRACT_SUB_INDEX = 0n;
+
+// Characters of a hex string.
+export const hexRegex = /^[0-9a-fA-F]+$/;

--- a/front-end-tools/src/constants.ts
+++ b/front-end-tools/src/constants.ts
@@ -44,10 +44,10 @@ export const hexRegex = /^[0-9a-fA-F]+$/;
 // Module reference displayed as placeholder in the input field.
 export const MODULE_REFERENCE_PLACEHOLDER = '91225f9538ac2903466cc4ab07b6eb607a2cd349549f357dfdf4e6042dde0693';
 
-// Available options to select in step 2 for deriving values from the module references.
+// Available options to select in step 2 for deriving values from the module reference.
 export const DO_NOT_DERIVE = { value: "Don't derive", label: "Don't derive" };
 export const DERIVE_FROM_STEP_1 = { value: 'Derive from step 1', label: 'Derive from step 1' };
 export const DERIVE_FROM_CHAIN = { value: 'Derive from chain', label: 'Derive from chain' };
 
-// All available options to select in step 2 for deriving values from the module references.
+// All available options to select in step 2 for deriving values from the module reference.
 export const OPTIONS_DERIVE_FROM_MODULE_REFERENCE = [DO_NOT_DERIVE, DERIVE_FROM_STEP_1, DERIVE_FROM_CHAIN];

--- a/front-end-tools/src/reading_from_blockchain.ts
+++ b/front-end-tools/src/reading_from_blockchain.ts
@@ -39,6 +39,21 @@ export async function getContractInfo(rpcClient: ConcordiumGRPCClient | undefine
     return returnValue;
 }
 
+/** This function gets the module source of a module reference. */
+export async function getModuleSource(
+    rpcClient: ConcordiumGRPCClient | undefined,
+    moduleRef: ModuleReference.Type | undefined
+) {
+    if (rpcClient === undefined) {
+        throw new Error(`rpcClient undefined`);
+    }
+    if (moduleRef === undefined) {
+        throw new Error(`Set module ref`);
+    }
+
+    return rpcClient.getModuleSource(moduleRef);
+}
+
 /** This function gets the embedded schema of a module reference. */
 export async function getEmbeddedSchema(
     rpcClient: ConcordiumGRPCClient | undefined,

--- a/front-end-tools/src/writing_to_blockchain.ts
+++ b/front-end-tools/src/writing_to_blockchain.ts
@@ -139,7 +139,9 @@ export async function initialize(
 ) {
     if (moduleReferenceAlreadyDeployed === false) {
         throw new Error(
-            `Module reference does not exist on chain. First, deploy your module in step 1 and change/refresh the module reference field in step 2 to remove this error.`
+            `Module reference does not exist on chain. Enter a valid module reference or deploy your module in step 1 first.
+           The step 2 box will not automatically reload the new module reference, 
+           you might want to select "Don't derive" and then select "Derive from chain/Derive from Step1" again to load the new module reference`
         );
     }
 

--- a/front-end-tools/src/writing_to_blockchain.ts
+++ b/front-end-tools/src/writing_to_blockchain.ts
@@ -131,7 +131,7 @@ export async function initialize(
     inputParameter: string | undefined,
     contractName: ContractName.Type | undefined,
     hasInputParameter: boolean,
-    useModuleFromStep1: boolean,
+    deriveFromModuleRefernce: string | undefined,
     moduleSchema: string | undefined,
     inputParamterType: string | undefined,
     maxContractExecutionEnergy: Energy.Type,
@@ -154,9 +154,9 @@ export async function initialize(
     let params: TypedSmartContractParameters | undefined;
 
     if (hasInputParameter) {
-        if (!useModuleFromStep1 && moduleSchema === undefined) {
+        if ((deriveFromModuleRefernce === "Don't derive" || undefined) && moduleSchema === undefined) {
             throw new Error(`Set schema`);
-        } else if (useModuleFromStep1 && moduleSchema === undefined) {
+        } else if (moduleSchema === undefined) {
             throw new Error(`No embedded module schema found in module`);
         }
 

--- a/front-end-tools/src/writing_to_blockchain.ts
+++ b/front-end-tools/src/writing_to_blockchain.ts
@@ -16,7 +16,7 @@ import {
 } from '@concordium/web-sdk';
 import { TypedSmartContractParameters, WalletConnection } from '@concordium/react-components';
 import { moduleSchemaFromBase64 } from '@concordium/wallet-connectors';
-import { CONTRACT_SUB_INDEX } from './constants';
+import { CONTRACT_SUB_INDEX, DERIVE_FROM_CHAIN, DERIVE_FROM_STEP_1, DO_NOT_DERIVE } from './constants';
 
 /** This function signs and sends a `DeployModule` transaction.
  */
@@ -140,8 +140,8 @@ export async function initialize(
     if (moduleReferenceAlreadyDeployed === false) {
         throw new Error(
             `Module reference does not exist on chain. Enter a valid module reference or deploy your module in step 1 first.
-           The step 2 box will not automatically reload the new module reference, 
-           you might want to select "Don't derive" and then select "Derive from chain/Derive from Step1" again to load the new module reference`
+           The step 2 box will not automatically derive values from the new module reference, 
+           you might want to select "${DERIVE_FROM_STEP_1.label}/${DERIVE_FROM_CHAIN.label}" again to derive values from the new module reference`
         );
     }
 
@@ -156,7 +156,7 @@ export async function initialize(
     let params: TypedSmartContractParameters | undefined;
 
     if (hasInputParameter) {
-        if ((deriveFromModuleRefernce === "Don't derive" || undefined) && moduleSchema === undefined) {
+        if ((deriveFromModuleRefernce === DO_NOT_DERIVE.value || undefined) && moduleSchema === undefined) {
             throw new Error(`Set schema`);
         } else if (moduleSchema === undefined) {
             throw new Error(`No embedded module schema found in module`);

--- a/front-end-tools/src/writing_to_blockchain.ts
+++ b/front-end-tools/src/writing_to_blockchain.ts
@@ -18,7 +18,17 @@ import { TypedSmartContractParameters, WalletConnection } from '@concordium/reac
 import { moduleSchemaFromBase64 } from '@concordium/wallet-connectors';
 import { CONTRACT_SUB_INDEX, DERIVE_FROM_CHAIN, DERIVE_FROM_STEP_1, DO_NOT_DERIVE } from './constants';
 
-/** This function signs and sends a `DeployModule` transaction.
+/**
+ * This function signs and sends a `DeployModule` transaction. A promise is returned for the hash of the submitted transaction.
+ * This type of transaction deploys a new Wasm module on chain.
+ *
+ * @param connection the wallet connection to submit the transaction to.
+ * @param account the account whose keys are used to sign the transaction.
+ * @param base64Module the Wasm module in base64 format to be deployed.
+ *
+ * @returns A promise for the hash of the submitted transaction.
+ * @throws If the `base64Module` is undefined.
+ * @throws If the request to the wallet fails.
  */
 export async function deploy(
     connection: WalletConnection,
@@ -34,20 +44,40 @@ export async function deploy(
     } as DeployModulePayload);
 }
 
-/** This function signs and sends an `Update` transaction.
- * If the transaction should include an input parameter, `hasInputParameter` needs to be true
- * and the `inputParameter`, its `inputParameterType`, and the contract `moduleSchema` have to be provided.
+/**
+ * This function signs and sends an `Update` transaction. A promise is returned for the hash of the submitted transaction.
+ * This type of transaction updates a new smart contract instance on chain.
+ * If the `hasInputParameter` is true, the `inputParameter` and its `inputParameterType`, and the contract `moduleSchema` have to
+ * be provided so that the input parameter can be serialized.
+ *
+ * @param connection the wallet connection to submit the transaction to.
+ * @param account the account whose keys are used to sign the transaction.
+ * @param contractName the contract name.
+ * @param entryPoint the entrypoint name.
+ * @param deriveContractInfoFromIndex a boolean signaling if values were derived from the contract index or manually inputted by the user.
+ * @param hasInputParameter a boolean signaling if the init function has an input parameter.
+ * @param inputParameter an optional input parameter.
+ * @param inputParameterType  an optional input parameter type (`string`/`number`/`array`/`object`).
+ * @param moduleSchema an optional module schema to serialize the input parameter.
+ * @param maxContractExecutionEnergy the maximum amount of energy to be used while executing the transaction.
+ * @param contractIndex the contract index (part of the smart contract address).
+ * @param amount the amount of micro CCD to send.
+ *
+ * @returns A promise for the hash of the submitted transaction.
+ * @throws If the `entryPoint` is undefined.
+ * @throws If the `hasInputParameter` is true but the input parameter cannot be serialized.
+ * @throws If the request to the wallet fails.
  */
 export async function update(
     connection: WalletConnection,
     account: AccountAddress.Type,
-    inputParameter: string | undefined,
     contractName: ContractName.Type,
     entryPoint: EntrypointName.Type | undefined,
+    deriveContractInfoFromIndex: boolean,
     hasInputParameter: boolean,
-    deriveContractInfo: boolean,
-    moduleSchema: string | undefined,
+    inputParameter: string | undefined,
     inputParameterType: string | undefined,
+    moduleSchema: string | undefined,
     maxContractExecutionEnergy: Energy.Type,
     contractIndex: bigint,
     amount: CcdAmount.Type
@@ -59,9 +89,9 @@ export async function update(
     let params: TypedSmartContractParameters | undefined;
 
     if (hasInputParameter) {
-        if (!deriveContractInfo && moduleSchema === undefined) {
+        if (!deriveContractInfoFromIndex && moduleSchema === undefined) {
             throw new Error(`Set schema`);
-        } else if (deriveContractInfo && moduleSchema === undefined) {
+        } else if (deriveContractInfoFromIndex && moduleSchema === undefined) {
             throw new Error(`No embedded module schema found in module`);
         }
 
@@ -100,7 +130,7 @@ export async function update(
                     };
                     break;
                 default:
-                    throw new Error(`Input paramter type option does not exist`);
+                    throw new Error(`Input parameter type option does not exist`);
             }
         }
     }
@@ -118,22 +148,43 @@ export async function update(
     );
 }
 
-/** This function signs and sends an `InitContract` transaction.
- * If the transaction should include an input parameter,
- * `hasInputParameter` needs to be true and the `inputParameter`,
- * its `inputParameterType`, and the contract `moduleSchema` have to be provided.
+/**
+ * This function signs and sends an `InitContract` transaction. A promise is returned for the hash of the submitted transaction.
+ * This type of transaction creates a new smart contract instance on chain.
+ * If the `hasInputParameter` is true, the `inputParameter` and its `inputParameterType`, and the contract `moduleSchema` have to
+ * be provided so that the input parameter can be serialized.
+ *
+ * @param connection the wallet connection to submit the transaction to.
+ * @param account the account whose keys are used to sign the transaction.
+ * @param moduleReferenceAlreadyDeployed a boolean signaling if the module is already deployed on chain.
+ * @param moduleReference the module's reference to initialize the smart contract instance from, represented by the ModuleReference class.
+ * @param contractName the contract name in case several contracts exist in the module.
+ * @param hasInputParameter a boolean signaling if the init function has an input parameter.
+ * @param inputParameter an optional input parameter.
+ * @param inputParameterType  an optional input parameter type (`string`/`number`/`array`/`object`).
+ * @param moduleSchema an optional module schema to serialize the input parameter.
+ * @param deriveFromModuleReference a value signalling how the module reference (and associated values) were derived (`doNotDerive`/`deriveFromStep1`/`deriveFromChain`).
+ * @param maxContractExecutionEnergy the maximum amount of energy to be used while executing the transaction.
+ * @param amount the amount of micro CCD to send.
+ *
+ * @returns A promise for the hash of the submitted transaction.
+ * @throws If the `moduleReferenceAlreadyDeployed` is false.
+ * @throws If the `moduleReference` is undefined.
+ * @throws If the `contractName` is undefined.
+ * @throws If the `hasInputParameter` is true but the input parameter cannot be serialized.
+ * @throws If the request to the wallet fails.
  */
 export async function initialize(
     connection: WalletConnection,
     account: AccountAddress.Type,
     moduleReferenceAlreadyDeployed: boolean,
     moduleReference: ModuleReference.Type | undefined,
-    inputParameter: string | undefined,
     contractName: ContractName.Type | undefined,
     hasInputParameter: boolean,
-    deriveFromModuleRefernce: string | undefined,
+    inputParameter: string | undefined,
+    inputParameterType: string | undefined,
     moduleSchema: string | undefined,
-    inputParamterType: string | undefined,
+    deriveFromModuleReference: string | undefined,
     maxContractExecutionEnergy: Energy.Type,
     amount: CcdAmount.Type
 ) {
@@ -156,22 +207,25 @@ export async function initialize(
     let params: TypedSmartContractParameters | undefined;
 
     if (hasInputParameter) {
-        if ((deriveFromModuleRefernce === DO_NOT_DERIVE.value || undefined) && moduleSchema === undefined) {
+        if (
+            (deriveFromModuleReference === DO_NOT_DERIVE.value || deriveFromModuleReference === undefined) &&
+            moduleSchema === undefined
+        ) {
             throw new Error(`Set schema`);
         } else if (moduleSchema === undefined) {
             throw new Error(`No embedded module schema found in module`);
         }
 
         if (moduleSchema !== undefined) {
-            if (inputParamterType === undefined) {
-                throw new Error(`Set input paramter type`);
+            if (inputParameterType === undefined) {
+                throw new Error(`Set input parameter type`);
             }
 
             if (inputParameter === undefined) {
                 throw new Error(`Set input parameter`);
             }
 
-            switch (inputParamterType) {
+            switch (inputParameterType) {
                 case 'number':
                     params = {
                         parameters: Number(inputParameter),
@@ -197,7 +251,7 @@ export async function initialize(
                     };
                     break;
                 default:
-                    throw new Error(`Input paramter type does not exist`);
+                    throw new Error(`Input parameter type does not exist`);
             }
         }
     }


### PR DESCRIPTION
## Purpose

closes #149 
Until now, people had to upload a module file at step 1 before they were able to derive values for initializing in step 2.
Now, there is a new option to derive the values in step 2 from the chain given a valid module reference.

## Changes

- Simplified interactions between Step 1 and Step 2. Only the moduleRefrence is now a shared state between the two boxes.
- Add option to `deriveFromChain` given a module reference in Step 2.
