### PR TITLE
Add decoding of error codes

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- Add decoding of a failed invoke transaction into a human-readable error.
+
 ## 3.1.0
 
 - Add option to `deriveFromChain` given a module reference in Step 2.

--- a/front-end-tools/package.json
+++ b/front-end-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "front-end-tools",
     "packageManager": "yarn@4.0.2",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=16.x"

--- a/front-end-tools/src/components/InitComponent.tsx
+++ b/front-end-tools/src/components/InitComponent.tsx
@@ -726,7 +726,7 @@ export default function InitComponent(props: ConnectionProps) {
                 )}
                 {smartContractIndex !== undefined && (
                     <div className="actionResultBox">
-                        Smart Contract Inedex:
+                        Smart Contract Index:
                         <div>{smartContractIndex}</div>
                     </div>
                 )}

--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -536,7 +536,20 @@ export default function ReadComponenet(props: ConnectionProps) {
 
                 <br />
                 <br />
-                {error && <Alert variant="danger"> Error: {error}. </Alert>}
+                {error && (
+                    <Alert variant="danger">
+                        {' '}
+                        Error: {error}.
+                        <br />
+                        <a href="https://docs.rs/concordium-std/latest/concordium_std/#signalling-errors">
+                            `Concordium-std` crate signalling errors
+                        </a>
+                        <br />
+                        <a href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/piggy-bank/deploying.html#concordium-std-crate-errors">
+                            Developer documentation: Explanation error codes
+                        </a>
+                    </Alert>
+                )}
                 {returnValue && (
                     <div className="actionResultBox">
                         Read value:

--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -546,7 +546,7 @@ export default function ReadComponenet(props: ConnectionProps) {
                         </a>
                         <br />
                         <a href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/piggy-bank/deploying.html#concordium-std-crate-errors">
-                            Developer documentation: Explanation error codes
+                            Developer documentation: Explanation of error codes
                         </a>
                     </Alert>
                 )}

--- a/front-end-tools/src/reading_from_blockchain.ts
+++ b/front-end-tools/src/reading_from_blockchain.ts
@@ -228,11 +228,16 @@ export async function read(
     const fullEntryPointName = `${contractName.value}.${entryPoint.value}`;
 
     if (!res || res.tag === 'failure') {
-        const rejectReason = decodeRejectReason(res, contractName, entryPoint, moduleSchema);
+        const [rejectReasonCode, humanReadableError] = decodeRejectReason(res, contractName, entryPoint, moduleSchema);
 
         throw new Error(
             `RPC call 'invokeContract' on method '${fullEntryPointName}' of contract '${contractIndex}' failed.
-            ${rejectReason !== undefined ? `Reject reason: ${rejectReason}` : ''}`
+            ${rejectReasonCode !== undefined ? `Reject reason code: ${rejectReasonCode}.` : ''} ${
+                humanReadableError !== undefined
+                    ? `Prettified reject reason: ${humanReadableError} (Warning: Prettified reject reason is not guaranteed to be correct.
+                    Check smart contract code to ensure error codes have not been overwritten.)`
+                    : ''
+            }`
         );
     }
 

--- a/front-end-tools/src/reading_from_blockchain.ts
+++ b/front-end-tools/src/reading_from_blockchain.ts
@@ -234,8 +234,12 @@ export async function read(
             `RPC call 'invokeContract' on method '${fullEntryPointName}' of contract '${contractIndex}' failed.
             ${rejectReasonCode !== undefined ? `Reject reason code: ${rejectReasonCode}.` : ''} ${
                 humanReadableError !== undefined
-                    ? `Prettified reject reason: ${humanReadableError} (Warning: Prettified reject reason is not guaranteed to be correct.
-                    Check smart contract code to ensure error codes have not been overwritten.)`
+                    ? `Prettified reject reason: ${humanReadableError} (Warning: A smart contract can have logic to
+                        overwrite/change the meaning of the error codes as defined in the concordium-std crate.
+                        While it is not advised to overwrite these error codes and is rather unusual to do so, it's important to note that
+                        this tool decodes the error codes based on the definitions in the concordium-std crate (assuming they have not been overwritten
+                        with other meanings in the smart contract logic). No guarantee are given as such that the meaning of the displayed prettified reject reason haven't been altered by the smart contract logic.
+                       )`
                     : ''
             }`
         );

--- a/front-end-tools/src/reading_from_blockchain.ts
+++ b/front-end-tools/src/reading_from_blockchain.ts
@@ -4,8 +4,6 @@ import {
     deserializeReceiveReturnValue,
     serializeUpdateContractParameters,
     ModuleReference,
-    InvokeContractFailedResult,
-    RejectedReceive,
     AccountAddress,
     AccountInfo,
     ContractAddress,
@@ -17,6 +15,7 @@ import {
 } from '@concordium/web-sdk';
 import JSONbig from 'json-bigint';
 import { CONTRACT_SUB_INDEX } from './constants';
+import { decodeRejectReason } from './utils';
 
 /**
  * Retrieves information about a given smart contract instance.
@@ -229,15 +228,14 @@ export async function read(
     const fullEntryPointName = `${contractName.value}.${entryPoint.value}`;
 
     if (!res || res.tag === 'failure') {
-        const rejectReason = JSON.stringify(
-            ((res as InvokeContractFailedResult)?.reason as RejectedReceive)?.rejectReason
-        );
+        const rejectReason = decodeRejectReason(res, contractName, entryPoint, moduleSchema);
 
         throw new Error(
             `RPC call 'invokeContract' on method '${fullEntryPointName}' of contract '${contractIndex}' failed.
             ${rejectReason !== undefined ? `Reject reason: ${rejectReason}` : ''}`
         );
     }
+
     if (!res.returnValue) {
         throw new Error(
             `RPC call 'invokeContract' on method '${fullEntryPointName}' of contract '${contractIndex}' returned no return_value`

--- a/front-end-tools/src/utils.ts
+++ b/front-end-tools/src/utils.ts
@@ -1,3 +1,11 @@
+import {
+    toBuffer,
+    InvokeContractFailedResult,
+    RejectedReceive,
+    deserializeReceiveError,
+    EntrypointName,
+    ContractName,
+} from '@concordium/web-sdk';
 import { EXAMPLE_ARRAYS, EXAMPLE_JSON_OBJECT } from './constants';
 
 export function arraysEqual(a: Uint8Array, b: Uint8Array) {
@@ -19,4 +27,66 @@ export function getObjectExample(template: string | undefined) {
 
 export function getArrayExample(template: string | undefined) {
     return template !== undefined ? JSON.stringify(JSON.parse(template), undefined, 2) : EXAMPLE_ARRAYS;
+}
+
+/**
+ * Decodes the reason for the transaction failure into a human-readable format.
+ *
+ * If the error is NOT caused by a smart contract logical revert, this function returns the reason in a human-readable format as follows:
+ * - `a human-readable rejectReason tag`. This can happen for example if the transaction runs out of energy. Such errors have tags that are human-readable (e.g. "OutOfEnergy").
+ *
+ * If the error is caused by a smart contract logical revert, this function returns the reason as follows:
+ *  - `a rejectReason code` if NO error schema is provided (e.g. -1, -2, -3, ...).
+ *  - `a human-readable error string` if an error schema is provided in the moduleSchema. This error schema is used to decode the above `rejectReason code` into a human-readable string.
+ *
+ * @param failedResult the failed invoke contract result.
+ * @param contractName the name of the contract.
+ * @param entryPoint the entry point name.
+ * @param moduleSchema an optional module schema. If provided, the rejectReason code as logged by the smart contract can be decoded into a human-readable error string.
+ *
+ * @returns a decoded human-readable reject reason string (falls back to return the error codes if a missing schema prevents the function from decoding the error codes into human-readable strings).
+ */
+export function decodeRejectReason(
+    failedResult: InvokeContractFailedResult,
+    contractName: ContractName.Type,
+    entryPoint: EntrypointName.Type,
+    moduleSchema: string | undefined
+) {
+    let rejectReason;
+
+    const errorReason = failedResult.reason;
+
+    if (errorReason.tag === 'RejectedReceive') {
+        // If the error is due to a logical smart contract revert (`RejectedReceive` type),
+        // get the rejectReason code (e.g. -1, -2, -3).
+        rejectReason = ((failedResult as InvokeContractFailedResult)?.reason as RejectedReceive)?.rejectReason;
+
+        // If a module schema is provided, deserialize the reject reason into a human-readable string.
+        if (moduleSchema !== undefined) {
+            // Note: The rejectReason codes are converted to the byte tags of the enum type in Rust. Errors are represented as an enum type in Concordium smart contracts.
+            // -1 => 0x00
+            // -2 => 0x01
+            // -3 => 0x02
+            // -4 => 0x03
+            // ...
+            // This conversion works as long as there ares no more then 256 (one byte) of different errors in the smart contract which should be sufficient for practical smart contracts.
+            const decodedError = deserializeReceiveError(
+                Uint8Array.from([Math.abs(rejectReason) - 1]).buffer,
+                toBuffer(moduleSchema, 'base64'),
+                contractName,
+                entryPoint
+            );
+
+            // The object only includes one key. Its key is the human-readable error string.
+            const key = Object.keys(decodedError);
+
+            // Convert the human-readable error to a JSON string.
+            rejectReason = JSON.stringify(key);
+        }
+    } else {
+        // If the error is not due to a logical smart contract revert, return the `errorReasonTag` instead (e.g. if the transactions runs out of energy)
+        rejectReason = errorReason.tag;
+    }
+
+    return rejectReason;
 }

--- a/front-end-tools/src/utils.ts
+++ b/front-end-tools/src/utils.ts
@@ -35,7 +35,10 @@ export function getArrayExample(template: string | undefined) {
  * If the error is NOT caused by a smart contract logical revert, this function returns the reason in a human-readable format as follows:
  * - `a human-readable rejectReason tag`. This can happen for example if the transaction runs out of energy. Such errors have tags that are human-readable (e.g. "OutOfEnergy").
  *
- * If the error is caused by a smart contract logical revert, this function returns the reason as follows:
+ * If the error is caused by a smart contract logical revert coming from the `concordium-std` crate, this function returns the reason in a human-readable format as follows:
+ * - `a human-readable error string` decoded from the `concordium-std` crate error codes.
+ *
+ * If the error is caused by a smart contract logical revert coming from the smart contract itself, this function returns the reason as follows:
  *  - `a rejectReason code` if NO error schema is provided (e.g. -1, -2, -3, ...).
  *  - `a human-readable error string` if an error schema is provided in the moduleSchema. This error schema is used to decode the above `rejectReason code` into a human-readable string.
  *
@@ -57,31 +60,114 @@ export function decodeRejectReason(
     const errorReason = failedResult.reason;
 
     if (errorReason.tag === 'RejectedReceive') {
-        // If the error is due to a logical smart contract revert (`RejectedReceive` type),
-        // get the rejectReason code (e.g. -1, -2, -3).
+        // If the error is due to a logical smart contract revert (`RejectedReceive` type), get the `rejectReason` code.
+        // e.g. -1, -2, ... (if the error comes from the smart contract).
+        // e,g, -2147483647, -2147483646, ... (if the error comes from the `concordium-std` crate).
         rejectReason = ((failedResult as InvokeContractFailedResult)?.reason as RejectedReceive)?.rejectReason;
 
-        // If a module schema is provided, deserialize the reject reason into a human-readable string.
-        if (moduleSchema !== undefined) {
-            // Note: The rejectReason codes are converted to the byte tags of the enum type in Rust. Errors are represented as an enum type in Concordium smart contracts.
-            // -1 => 0x00
-            // -2 => 0x01
-            // -3 => 0x02
-            // -4 => 0x03
-            // ...
-            // This conversion works as long as there are no more then 256 (one byte) of different errors in the smart contract which should be sufficient for practical smart contracts.
-            const decodedError = deserializeReceiveError(
-                Uint8Array.from([Math.abs(rejectReason) - 1]).buffer,
-                toBuffer(moduleSchema, 'base64'),
-                contractName,
-                entryPoint
-            );
+        switch (rejectReason) {
+            // Check if the `rejectReason` comes from the `concordium-std` crate, and decode it into human-readable strings.
+            case -2147483647:
+                rejectReason = 'Error ()';
+                break;
+            case -2147483646:
+                rejectReason = 'ParseError';
+                break;
+            case -2147483645:
+                rejectReason = 'LogError::Full';
+                break;
+            case -2147483644:
+                rejectReason = 'LogError::Malformed';
+                break;
+            case -2147483643:
+                rejectReason = 'NewContractNameError::MissingInitPrefix';
+                break;
+            case -2147483642:
+                rejectReason = 'NewContractNameError::TooLong';
+                break;
+            case -2147483641:
+                rejectReason = 'NewReceiveNameError::MissingDotSeparator';
+                break;
+            case -2147483640:
+                rejectReason = 'NewReceiveNameError::TooLong';
+                break;
+            case -2147483639:
+                rejectReason = 'NewContractNameError::ContainsDot';
+                break;
+            case -2147483638:
+                rejectReason = 'NewContractNameError::InvalidCharacters';
+                break;
+            case -2147483637:
+                rejectReason = 'NewReceiveNameError::InvalidCharacters';
+                break;
+            case -2147483636:
+                rejectReason = 'NotPayableError';
+                break;
+            case -2147483635:
+                rejectReason = 'TransferError::AmountTooLarge';
+                break;
+            case -2147483634:
+                rejectReason = 'TransferError::MissingAccount';
+                break;
+            case -2147483633:
+                rejectReason = 'CallContractError::AmountTooLarge';
+                break;
+            case -2147483632:
+                rejectReason = 'CallContractError::MissingAccount';
+                break;
+            case -2147483631:
+                rejectReason = 'CallContractError::MissingContract';
+                break;
+            case -2147483630:
+                rejectReason = 'CallContractError::MissingEntrypoint';
+                break;
+            case -2147483629:
+                rejectReason = 'CallContractError::MessageFailed';
+                break;
+            case -2147483628:
+                rejectReason = 'CallContractError::LogicReject';
+                break;
+            case -2147483627:
+                rejectReason = 'CallContractError::Trap';
+                break;
+            case -2147483626:
+                rejectReason = 'UpgradeError::MissingModule';
+                break;
+            case -2147483625:
+                rejectReason = 'UpgradeError::MissingContract';
+                break;
+            case -2147483624:
+                rejectReason = 'UpgradeError::UnsupportedModuleVersion';
+                break;
+            case -2147483623:
+                rejectReason = 'QueryAccountBalanceError';
+                break;
+            case -2147483622:
+                rejectReason = 'QueryContractBalanceError';
+                break;
+            default:
+                // If the `rejectReason` comes from the smart contract itself (e.g. -1, -2, -3, ...) and an error schema is provided in the module schema, deserialize the reject reason into a human-readable string.
+                if (moduleSchema !== undefined) {
+                    // Note: The rejectReason codes are converted to the byte tags of the enum type in Rust. Errors are represented as an enum type in Concordium smart contracts.
+                    // -1 => 0x00
+                    // -2 => 0x01
+                    // -3 => 0x02
+                    // -4 => 0x03
+                    // ...
+                    // This conversion works as long as there are no more then 256 (one byte) of different errors in the smart contract which should be sufficient for practical smart contracts.
+                    const decodedError = deserializeReceiveError(
+                        Uint8Array.from([Math.abs(rejectReason) - 1]).buffer,
+                        toBuffer(moduleSchema, 'base64'),
+                        contractName,
+                        entryPoint
+                    );
 
-            // The object only includes one key. Its key is the human-readable error string.
-            const key = Object.keys(decodedError);
+                    // The object only includes one key. Its key is the human-readable error string.
+                    const key = Object.keys(decodedError);
 
-            // Convert the human-readable error to a JSON string.
-            rejectReason = JSON.stringify(key);
+                    // Convert the human-readable error to a JSON string.
+                    return JSON.stringify(key);
+                }
         }
     } else {
         // If the error is not due to a logical smart contract revert, return the `errorReasonTag` instead (e.g. if the transactions runs out of energy)

--- a/front-end-tools/src/utils.ts
+++ b/front-end-tools/src/utils.ts
@@ -31,6 +31,102 @@ export function getArrayExample(template: string | undefined) {
 }
 
 /**
+ * Decodes the `rejectReasonCode` manually into a human-readable string based on the error code definition in the `concordium-std` crate.
+ * @param rejectReasonCode the reject reason error code.
+ *
+ * @returns a decoded human-readable error string if the error code is defined in the `concordium-std` crate otherwise returns `undefined`.
+ */
+export function decodeConcordiumStdError(rejectReasonCode: number | undefined) {
+    let humanReadableError;
+
+    switch (rejectReasonCode) {
+        // Check if the `rejectReason` comes from the `concordium-std` crate, and decode it into human-readable strings.
+        case -2147483647:
+            humanReadableError = '`[Error ()]`';
+            break;
+        case -2147483646:
+            humanReadableError = '`[ParseError]`';
+            break;
+        case -2147483645:
+            humanReadableError = '`[LogError::Full]`';
+            break;
+        case -2147483644:
+            humanReadableError = '`[LogError::Malformed]`';
+            break;
+        case -2147483643:
+            humanReadableError = '`[NewContractNameError::MissingInitPrefix]`';
+            break;
+        case -2147483642:
+            humanReadableError = '`[NewContractNameError::TooLong]`';
+            break;
+        case -2147483641:
+            humanReadableError = '`[NewReceiveNameError::MissingDotSeparator]`';
+            break;
+        case -2147483640:
+            humanReadableError = '`[NewReceiveNameError::TooLong]`';
+            break;
+        case -2147483639:
+            humanReadableError = '`[NewContractNameError::ContainsDot]`';
+            break;
+        case -2147483638:
+            humanReadableError = '`[NewContractNameError::InvalidCharacters]`';
+            break;
+        case -2147483637:
+            humanReadableError = '`[NewReceiveNameError::InvalidCharacters]`';
+            break;
+        case -2147483636:
+            humanReadableError = '`[NotPayableError]`';
+            break;
+        case -2147483635:
+            humanReadableError = '`[TransferError::AmountTooLarge]`';
+            break;
+        case -2147483634:
+            humanReadableError = '`[TransferError::MissingAccount]`';
+            break;
+        case -2147483633:
+            humanReadableError = '`[CallContractError::AmountTooLarge]`';
+            break;
+        case -2147483632:
+            humanReadableError = '`[CallContractError::MissingAccount]`';
+            break;
+        case -2147483631:
+            humanReadableError = '`[CallContractError::MissingContract]`';
+            break;
+        case -2147483630:
+            humanReadableError = '`[CallContractError::MissingEntrypoint]`';
+            break;
+        case -2147483629:
+            humanReadableError = '`[CallContractError::MessageFailed]`';
+            break;
+        case -2147483628:
+            humanReadableError = '`[CallContractError::LogicReject]`';
+            break;
+        case -2147483627:
+            humanReadableError = '`[CallContractError::Trap]`';
+            break;
+        case -2147483626:
+            humanReadableError = '`[UpgradeError::MissingModule]`';
+            break;
+        case -2147483625:
+            humanReadableError = '`[UpgradeError::MissingContract]`';
+            break;
+        case -2147483624:
+            humanReadableError = '`[UpgradeError::UnsupportedModuleVersion]`';
+            break;
+        case -2147483623:
+            humanReadableError = '`[QueryAccountBalanceError]`';
+            break;
+        case -2147483622:
+            humanReadableError = '`[QueryContractBalanceError]`';
+            break;
+        default:
+            humanReadableError = undefined;
+    }
+
+    return humanReadableError;
+}
+
+/**
  * Decodes the reason for the transaction failure. Depending on the type of the error and if an error schema in the module schema is provided,
  * this function decodes the error as much as possible. The assumption is that the error codes have not been overwritten in the smart contract.
  * The function returns a reject reason code and/or a human-readable error.
@@ -38,14 +134,14 @@ export function getArrayExample(template: string | undefined) {
  * If the error is NOT caused by a smart contract logical revert, this function returns the reason in a human-readable format as follows:
  * - `humanReadableError = a human-readable rejectReason tag; rejectReasonCode = undefined)`. This can happen for example if the transaction runs out of energy. Such errors have tags that are human-readable (e.g. "OutOfEnergy").
  *
- * If the error is caused by a smart contract logical revert coming from the `concordium-std` crate, this function returns the reason in a human-readable format as well as the reject reason code as follows:
- * - `humanReadableError = a human-readable error string decoded from the `concordium-std` crate error codes; rejectReasonCode = reject reason code from the `concordium-std` crate`.
- *
  * If the error is caused by a smart contract logical revert coming from the smart contract itself, this function returns the reason as follows:
  *  - If NO error schema is provided:
  *    `humanReadableError = undefined; rejectReasonCode = a rejectReason code as defined in the smart contract (e.g. -1, -2, -3, ...)`.
  *  - If an error schema is provided in the moduleSchema:
  *    `humanReadableError = a human-readable error string; rejectReasonCode = a rejectReason code as defined in the smart contract`. The error schema is used to decode the `rejectReasonCode` into a human-readable string.
+ *
+ * If the error is caused by a smart contract logical revert coming from the `concordium-std` crate, this function returns the reason in a human-readable format as well as the reject reason code as follows:
+ * - `humanReadableError = a human-readable error string decoded from the `concordium-std` crate error codes; rejectReasonCode = reject reason code from the `concordium-std` crate`.
  *
  * @param failedResult the failed invoke contract result.
  * @param contractName the name of the contract.
@@ -72,106 +168,44 @@ export function decodeRejectReason(
         // e,g, -2147483647, -2147483646, ... (if the error comes from the `concordium-std` crate).
         rejectReasonCode = ((failedResult as InvokeContractFailedResult)?.reason as RejectedReceive)?.rejectReason;
 
-        switch (rejectReasonCode) {
-            // Check if the `rejectReason` comes from the `concordium-std` crate, and decode it into human-readable strings.
-            case -2147483647:
-                humanReadableError = '`[Error ()]`';
-                break;
-            case -2147483646:
-                humanReadableError = '`[ParseError]`';
-                break;
-            case -2147483645:
-                humanReadableError = '`[LogError::Full]`';
-                break;
-            case -2147483644:
-                humanReadableError = '`[LogError::Malformed]`';
-                break;
-            case -2147483643:
-                humanReadableError = '`[NewContractNameError::MissingInitPrefix]`';
-                break;
-            case -2147483642:
-                humanReadableError = '`[NewContractNameError::TooLong]`';
-                break;
-            case -2147483641:
-                humanReadableError = '`[NewReceiveNameError::MissingDotSeparator]`';
-                break;
-            case -2147483640:
-                humanReadableError = '`[NewReceiveNameError::TooLong]`';
-                break;
-            case -2147483639:
-                humanReadableError = '`[NewContractNameError::ContainsDot]`';
-                break;
-            case -2147483638:
-                humanReadableError = '`[NewContractNameError::InvalidCharacters]`';
-                break;
-            case -2147483637:
-                humanReadableError = '`[NewReceiveNameError::InvalidCharacters]`';
-                break;
-            case -2147483636:
-                humanReadableError = '`[NotPayableError]`';
-                break;
-            case -2147483635:
-                humanReadableError = '`[TransferError::AmountTooLarge]`';
-                break;
-            case -2147483634:
-                humanReadableError = '`[TransferError::MissingAccount]`';
-                break;
-            case -2147483633:
-                humanReadableError = '`[CallContractError::AmountTooLarge]`';
-                break;
-            case -2147483632:
-                humanReadableError = '`[CallContractError::MissingAccount]`';
-                break;
-            case -2147483631:
-                humanReadableError = '`[CallContractError::MissingContract]`';
-                break;
-            case -2147483630:
-                humanReadableError = '`[CallContractError::MissingEntrypoint]`';
-                break;
-            case -2147483629:
-                humanReadableError = '`[CallContractError::MessageFailed]`';
-                break;
-            case -2147483628:
-                humanReadableError = '`[CallContractError::LogicReject]`';
-                break;
-            case -2147483627:
-                humanReadableError = '`[CallContractError::Trap]`';
-                break;
-            case -2147483626:
-                humanReadableError = '`[UpgradeError::MissingModule]`';
-                break;
-            case -2147483625:
-                humanReadableError = '`[UpgradeError::MissingContract]`';
-                break;
-            case -2147483624:
-                humanReadableError = '`[UpgradeError::UnsupportedModuleVersion]`';
-                break;
-            case -2147483623:
-                humanReadableError = '`[QueryAccountBalanceError]`';
-                break;
-            case -2147483622:
-                humanReadableError = '`[QueryContractBalanceError]`';
-                break;
-            default:
-                // If the `rejectReason` comes from the smart contract itself (e.g. -1, -2, -3, ...)
-                // and an error schema is provided in the module schema, deserialize the reject reason into a human-readable string.
-                if (moduleSchema !== undefined && failedResult.returnValue !== undefined) {
-                    const decodedError = deserializeReceiveError(
-                        ReturnValue.toBuffer(failedResult.returnValue),
-                        toBuffer(moduleSchema, 'base64'),
-                        contractName,
-                        entryPoint
-                    );
+        // The `NotPayableError (-2147483636)` is special since it is the only error from the `concordium-std` crate which is not matched to a smart contract error in a valid errorSchema embedded in the module.
+        if (rejectReasonCode !== -2147483636) {
+            // If the `rejectReason` comes from the smart contract itself (e.g. -1, -2, -3, ...)
+            // and an error schema is provided in the module schema, deserialize the reject reason into a human-readable string.
+            // This is the recommended way to represent errors. As a result, we try first
+            // to deserialize the error with the schema before falling back to decode the `concordium-std` crate errors manually.
+            // Only the `NotPayableError` is treated special since it has no matched error in the errorSchema.
+            if (moduleSchema !== undefined && failedResult.returnValue !== undefined) {
+                const decodedError = deserializeReceiveError(
+                    ReturnValue.toBuffer(failedResult.returnValue),
+                    toBuffer(moduleSchema, 'base64'),
+                    contractName,
+                    entryPoint
+                );
 
+                if (decodedError !== undefined) {
                     // The object only includes one key. Its key is the human-readable error string.
                     const key = Object.keys(decodedError);
 
                     // Convert the human-readable error to a JSON string.
                     humanReadableError = JSON.stringify(key);
+                } else {
+                    // Falling back to decode the `concordium-std` crate errors manually
+                    // Decode the `rejectReason` based on the error codes defined in `concordium-std` crate, and decode it into a human-readable string if possible.
+                    humanReadableError = decodeConcordiumStdError(rejectReasonCode);
                 }
+            } else {
+                // Falling back to decode the `concordium-std` crate errors manually
+                // Decode the `rejectReason` based on the error codes defined in `concordium-std` crate, and decode it into a human-readable string if possible.
+                humanReadableError = decodeConcordiumStdError(rejectReasonCode);
+            }
+        } else {
+            // Falling back to decode the `concordium-std` crate errors manually
+            // Decode the `rejectReason` based on the error codes defined in `concordium-std` crate, and decode it into a human-readable string if possible.
+            humanReadableError = '`[NotPayableError]`';
         }
     } else {
-        // If the error is not due to a logical smart contract revert, return the `errorReasonTag` instead (e.g. if the transactions runs out of energy)
+        // If the error is not due to a logical smart contract revert, return the `errorReasonTag` instead (e.g. if the transaction runs out of energy)
         humanReadableError = `\`[${errorReason.tag}]\``;
     }
 

--- a/front-end-tools/src/utils.ts
+++ b/front-end-tools/src/utils.ts
@@ -42,9 +42,9 @@ export function getArrayExample(template: string | undefined) {
  * @param failedResult the failed invoke contract result.
  * @param contractName the name of the contract.
  * @param entryPoint the entry point name.
- * @param moduleSchema an optional module schema. If provided, the rejectReason code as logged by the smart contract can be decoded into a human-readable error string.
+ * @param moduleSchema an optional module schema including an error schema. If provided, the rejectReason code as logged by the smart contract can be decoded into a human-readable error string.
  *
- * @returns a decoded human-readable reject reason string (falls back to return the error codes if a missing schema prevents the function from decoding the error codes into human-readable strings).
+ * @returns a decoded human-readable reject reason string (or falls back to return the error codes if decoding is impossible).
  */
 export function decodeRejectReason(
     failedResult: InvokeContractFailedResult,
@@ -69,7 +69,7 @@ export function decodeRejectReason(
             // -3 => 0x02
             // -4 => 0x03
             // ...
-            // This conversion works as long as there ares no more then 256 (one byte) of different errors in the smart contract which should be sufficient for practical smart contracts.
+            // This conversion works as long as there are no more then 256 (one byte) of different errors in the smart contract which should be sufficient for practical smart contracts.
             const decodedError = deserializeReceiveError(
                 Uint8Array.from([Math.abs(rejectReason) - 1]).buffer,
                 toBuffer(moduleSchema, 'base64'),


### PR DESCRIPTION
## Purpose

The front end only displayed the error codes such as (-1, -2, -3) when the invoke of a transaction failed. Decoding the error into a human-readable message is preferred and gives better feedback to the users.

## Changes

- Add decoding of a failed invoke transaction into a human-readable error in the `scTool`.


