### PR TITLE
Use fixed tag for docker image in jenkins job

### DIFF
--- a/cargo-concordium/scripts/linux-cargo-concordium.Jenkinsfile
+++ b/cargo-concordium/scripts/linux-cargo-concordium.Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
             agent { 
                 docker {
                     reuseNode true
-                    image 'concordium/base:latest'
+                    image 'concordium/base:rust1.73-ghc9.6.4'
                     args '-u root'
                 } 
             }


### PR DESCRIPTION
## Purpose

The jenkins build job uses the docker image `concordium-base:latest` which currently is using an older version of rust.
This fixes the docker image to a specific tag.


