### PR TITLE
Added option for tags to cargo init

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Added a `tag` option to `cargo concordium init`
+
 ## 3.3.0
 
 - Bump minimum Rust version to 1.73.

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -780,7 +780,7 @@ pub fn build_contract_schema<A>(
 /// Create a new Concordium smart contract project from a template, or there
 /// are runtime exceptions that are not expected then this function returns
 /// `Err(...)`.
-pub fn init_concordium_project(path: impl AsRef<Path>) -> anyhow::Result<()> {
+pub fn init_concordium_project(path: impl AsRef<Path>, tag: &str) -> anyhow::Result<()> {
     let path = path.as_ref();
 
     let absolute_path = if path.is_absolute() {
@@ -802,6 +802,8 @@ pub fn init_concordium_project(path: impl AsRef<Path>) -> anyhow::Result<()> {
             "--git",
             "https://github.com/Concordium/concordium-rust-smart-contracts",
             "templates",
+            "--tag",
+            tag,
         ])
         .args(["--destination", absolute_path.to_str().unwrap()])
         .stdout(Stdio::inherit())

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -109,6 +109,14 @@ This command also builds a deployable Wasm module for integration testing, and i
             help = "The path where the project should be created."
         )]
         path: PathBuf,
+        #[structopt(
+            name = "tag",
+            long = "tag",
+            short = "t",
+            default_value = "releases/templates/latest",
+            help = "The release tag of the template to use."
+        )]
+        tag:  String,
     },
     #[structopt(
         name = "schema-json",
@@ -676,8 +684,8 @@ pub fn main() -> anyhow::Result<()> {
 
             eprintln!("{}", Color::Green.bold().paint("All tests passed"));
         }
-        Command::Init { path } => {
-            init_concordium_project(path)
+        Command::Init { path, tag } => {
+            init_concordium_project(path, &tag)
                 .context("Could not create a new Concordium smart contract project.")?;
         }
         Command::SchemaJSON {


### PR DESCRIPTION
## Purpose

Fixes #331

## Changes

Added a `tag` option to `cargo concordium init`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.