### PR TITLE
Expose test module output path

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased changes
 
 - Added a `tag` option to `cargo concordium init`
+- When running integration tests the module output path is now exposed to the
+  tests via the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.
 
 ## 3.3.0
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -122,6 +122,8 @@ pub struct BuildInfo {
     /// list of file paths that were used to build the artifact. The file
     /// paths are relative to the package root.
     pub stored_build_info: Option<(utils::VersionedBuildInfo, Vec<PathBuf>)>,
+    /// The path to the file of the built module.
+    pub out_filename:      PathBuf,
 }
 
 /// Result of [`create_archive`]. It contains the actual archive with a
@@ -632,12 +634,13 @@ pub(crate) fn build_contract(
     (output_bytes[4..8]).copy_from_slice(&data_size.to_be_bytes());
 
     let total_module_len = output_bytes.len();
-    fs::write(out_filename, output_bytes).context("Unable to write final module.")?;
+    fs::write(&out_filename, output_bytes).context("Unable to write final module.")?;
     Ok(BuildInfo {
         total_module_len,
         schema: return_schema,
         stored_build_info: stored_build_info.map(|(bi, a)| (bi, a.archived_files)),
         metadata,
+        out_filename,
     })
 }
 
@@ -1135,13 +1138,14 @@ pub(crate) fn build_and_run_integration_tests(
 
     // Build the module in the same way as `cargo concordium build`, except that
     // schema information shouldn't be printed.
-    let metadata = crate::handle_build(build_options, false)?;
+    let build_info = crate::handle_build(build_options, false)?;
 
     let mut cargo_test_args = vec!["test"];
 
     let test_targets: Vec<String> = if test_targets.is_empty() {
         // Find all the integration test targets and include them in the test.
-        metadata
+        build_info
+            .metadata
             .root_package()
             .context("Could not determine package.")?
             .targets
@@ -1202,6 +1206,13 @@ pub(crate) fn build_and_run_integration_tests(
 
         command.env("CARGO_CONCORDIUM_TEST_ALLOW_DEBUG", "1");
     }
+    // This enviroment variable needs to match the
+    // `CONTRACT_MODULE_OUTPUT_PATH_ENV_VAR` constant in the `contract-testing`
+    // crate.
+    command.env(
+        "CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH",
+        build_info.out_filename,
+    );
     // Output what we are doing so that it is easier to debug if the user
     // has their own features or options.
     eprint!("{} cargo", Color::Green.bold().paint("Running"),);

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -635,6 +635,9 @@ pub(crate) fn build_contract(
 
     let total_module_len = output_bytes.len();
     fs::write(&out_filename, output_bytes).context("Unable to write final module.")?;
+
+    // File name cannot be canonicalized before the file exists, so we do it here.
+    let out_filename = out_filename.canonicalize()?;
     Ok(BuildInfo {
         total_module_len,
         schema: return_schema,

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -1094,7 +1094,7 @@ fn handle_build(options: BuildOptions, print_extra_info: bool) -> anyhow::Result
     if print_extra_info {
         if let Some((bi, archived_files)) = &build_info.stored_build_info {
             eprintln!("  Embedded build information information:\n",);
-            print_build_info(&bi);
+            print_build_info(bi);
             eprintln!();
             eprintln!("    - Archived source files:");
             for file in archived_files {


### PR DESCRIPTION
## Purpose

Addresses https://github.com/Concordium/concordium-rust-smart-contracts/issues/383.

## Changes

When running integration tests the module output path is now exposed to the tests via the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.