### PR TITLE
Display raw bytes as hex string instead of a buffer

### DIFF
--- a/front-end-tools/CHANGELOG.md
+++ b/front-end-tools/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Display the raw bytes returned from the smart contract as hex string instead of buffer if no schema is provided.
+
 ## 3.1.1
 
 - Add decoding of a failed invoke transaction into a human-readable error.

--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -68,6 +68,7 @@ export default function ReadComponenet(props: ConnectionProps) {
         | undefined
     >(undefined);
     const [returnValue, setReturnValue] = useState<string | undefined>(undefined);
+    const [errorContractInvoke, setErrorContractInvoke] = useState<string | undefined>(undefined);
     const [error, setError] = useState<string | undefined>(undefined);
 
     const [entryPointTemplate, setEntryPointTemplate] = useState<string | undefined>(undefined);
@@ -135,7 +136,7 @@ export default function ReadComponenet(props: ConnectionProps) {
     }, [entryPointName, hasInputParameter, smartContractName, uploadedModuleSchemaBase64, inputParameterType]);
 
     function onSubmit(data: FormType) {
-        setError(undefined);
+        setErrorContractInvoke(undefined);
         setReturnValue(undefined);
 
         const schema = data.deriveFromSmartContractIndex ? embeddedModuleSchemaBase64 : uploadedModuleSchemaBase64;
@@ -158,7 +159,7 @@ export default function ReadComponenet(props: ConnectionProps) {
             .then((value) => {
                 setReturnValue(value);
             })
-            .catch((err: Error) => setError((err as Error).message));
+            .catch((err: Error) => setErrorContractInvoke((err as Error).message));
     }
 
     return (
@@ -536,20 +537,21 @@ export default function ReadComponenet(props: ConnectionProps) {
 
                 <br />
                 <br />
-                {error && (
+                {errorContractInvoke && (
                     <Alert variant="danger">
                         {' '}
-                        Error: {error}.
-                        <br />
-                        <a href="https://docs.rs/concordium-std/latest/concordium_std/#signalling-errors">
-                            `Concordium-std` crate signalling errors
-                        </a>
+                        Error: {errorContractInvoke}.
                         <br />
                         <a href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/piggy-bank/deploying.html#concordium-std-crate-errors">
                             Developer documentation: Explanation of error codes
                         </a>
+                        <br />
+                        <a href="https://docs.rs/concordium-std/latest/concordium_std/#signalling-errors">
+                            `Concordium-std` crate signalling errors
+                        </a>
                     </Alert>
                 )}
+                {error && <Alert variant="danger"> Error: {error}.</Alert>}
                 {returnValue && (
                     <div className="actionResultBox">
                         Read value:

--- a/front-end-tools/src/reading_from_blockchain.ts
+++ b/front-end-tools/src/reading_from_blockchain.ts
@@ -251,9 +251,12 @@ export async function read(
         );
     }
 
+    // If no schema is provided, return the raw bytes as a hex string.
     if (moduleSchema === undefined) {
-        // If no schema is provided return the raw bytes as a hex string.
-        return JSONbig.stringify(`0x${uint8ArrayToHexString(res.returnValue.buffer)}`);
+        // Convert the Uint8Array to a hex string.
+        const hexString = uint8ArrayToHexString(res.returnValue.buffer);
+
+        return JSONbig.stringify({ rawBytes: `0x${hexString}` });
     }
 
     let returnValue;

--- a/front-end-tools/src/reading_from_blockchain.ts
+++ b/front-end-tools/src/reading_from_blockchain.ts
@@ -15,7 +15,7 @@ import {
 } from '@concordium/web-sdk';
 import JSONbig from 'json-bigint';
 import { CONTRACT_SUB_INDEX } from './constants';
-import { decodeRejectReason } from './utils';
+import { decodeRejectReason, uint8ArrayToHexString } from './utils';
 
 /**
  * Retrieves information about a given smart contract instance.
@@ -252,8 +252,8 @@ export async function read(
     }
 
     if (moduleSchema === undefined) {
-        // If no schema is provided return the raw bytes
-        return JSONbig.stringify(res.returnValue);
+        // If no schema is provided return the raw bytes as a hex string.
+        return JSONbig.stringify(`0x${uint8ArrayToHexString(res.returnValue.buffer)}`);
     }
 
     let returnValue;

--- a/front-end-tools/src/utils.ts
+++ b/front-end-tools/src/utils.ts
@@ -20,6 +20,18 @@ export function arraysEqual(a: Uint8Array, b: Uint8Array) {
     return true;
 }
 
+/**
+ * Decodes a `Uint8Array` into a hex string.
+ * @param uint8Array the `Uint8Array`.
+ *
+ * @returns a hex string.
+ */
+export function uint8ArrayToHexString(uint8Array: Uint8Array) {
+    return Array.from(uint8Array)
+        .map((byte) => byte.toString(16).padStart(2, '0'))
+        .join('');
+}
+
 export function getObjectExample(template: string | undefined) {
     return template !== undefined
         ? JSON.stringify(JSON.parse(template), undefined, 2)


### PR DESCRIPTION
## Purpose

closes https://github.com/Concordium/concordium-smart-contract-tools/issues/146


## Changes

- Display the raw bytes returned from the smart contract as hex string instead of buffer if no schema is provided.
- Distinguish between `errors` from the `ContractInvoke` and the `deriveFromContractIndex` flow. The later errors have no `errorCodes` so displaying links to error codes don't make sense for the later.