### PR TITLE
Prettified error reporting

### DIFF
--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -162,10 +162,10 @@ export default function ReadComponenet(props: ConnectionProps) {
 
         promise
             .then((res) => {
-                if (!res || res.tag === 'failure' || !res.returnValue) {
-                    const er = parseError(res, contractName, contractIndex, entryPoint, schema);
-                    setAddDisclaimer(er?.addDisclaimer);
-                    setErrorContractInvoke(er?.errors);
+                if (res.tag === 'failure') {
+                    const parsedError = parseError(res, contractName, contractIndex, entryPoint, schema);
+                    setAddDisclaimer(parsedError?.addDisclaimer);
+                    setErrorContractInvoke(parsedError?.errors);
                 } else {
                     const parsedValue = parseResult(res, contractName, contractIndex, entryPoint, schema);
                     setReturnValue(parsedValue);
@@ -554,11 +554,21 @@ export default function ReadComponenet(props: ConnectionProps) {
                         ))}
 
                         <br />
-                        <a href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/piggy-bank/deploying.html#concordium-std-crate-errors">
+                        <a
+                            className="link"
+                            target="_blank"
+                            rel="noreferrer"
+                            href="https://developer.concordium.software/en/mainnet/smart-contracts/tutorials/piggy-bank/deploying.html#concordium-std-crate-errors"
+                        >
                             Developer documentation: Explanation of errors
                         </a>
                         <br />
-                        <a href="https://docs.rs/concordium-std/latest/concordium_std/#signalling-errors">
+                        <a
+                            className="link"
+                            target="_blank"
+                            rel="noreferrer"
+                            href="https://docs.rs/concordium-std/latest/concordium_std/#signalling-errors"
+                        >
                             `Concordium-std` crate signalling errors
                         </a>
                     </Alert>

--- a/front-end-tools/src/components/ReadComponent.tsx
+++ b/front-end-tools/src/components/ReadComponent.tsx
@@ -14,7 +14,7 @@ import {
 } from '@concordium/web-sdk';
 
 import Box from './Box';
-import { read, parseResult, getEmbeddedSchema, getContractInfo, parseError } from '../reading_from_blockchain';
+import { read, parseReturnValue, getEmbeddedSchema, getContractInfo, parseError } from '../reading_from_blockchain';
 import { getObjectExample, getArrayExample } from '../utils';
 import { INPUT_PARAMETER_TYPES_OPTIONS } from '../constants';
 
@@ -164,10 +164,10 @@ export default function ReadComponenet(props: ConnectionProps) {
             .then((res) => {
                 if (res.tag === 'failure') {
                     const parsedError = parseError(res, contractName, contractIndex, entryPoint, schema);
-                    setAddDisclaimer(parsedError?.addDisclaimer);
-                    setErrorContractInvoke(parsedError?.errors);
+                    setAddDisclaimer(parsedError.addDisclaimer);
+                    setErrorContractInvoke(parsedError.errors);
                 } else {
-                    const parsedValue = parseResult(res, contractName, contractIndex, entryPoint, schema);
+                    const parsedValue = parseReturnValue(res, contractName, contractIndex, entryPoint, schema);
                     setReturnValue(parsedValue);
                 }
             })

--- a/front-end-tools/src/utils.ts
+++ b/front-end-tools/src/utils.ts
@@ -188,20 +188,19 @@ export function decodeRejectReason(
             // to deserialize the error with the schema before falling back to decode the `concordium-std` crate errors manually.
             // Only the `NotPayableError` is treated special since it has no matched error in the errorSchema.
             if (moduleSchema !== undefined && failedResult.returnValue !== undefined) {
-                const decodedError = deserializeReceiveError(
-                    ReturnValue.toBuffer(failedResult.returnValue),
-                    toBuffer(moduleSchema, 'base64'),
-                    contractName,
-                    entryPoint
-                );
-
-                if (decodedError !== undefined) {
+                try {
+                    const decodedError = deserializeReceiveError(
+                        ReturnValue.toBuffer(failedResult.returnValue),
+                        toBuffer(moduleSchema, 'base64'),
+                        contractName,
+                        entryPoint
+                    );
                     // The object only includes one key. Its key is the human-readable error string.
                     const key = Object.keys(decodedError);
 
                     // Convert the human-readable error to a JSON string.
                     humanReadableError = JSON.stringify(key);
-                } else {
+                } catch (_error) {
                     // Falling back to decode the `concordium-std` crate errors manually
                     // Decode the `rejectReason` based on the error codes defined in `concordium-std` crate, and decode it into a human-readable string if possible.
                     humanReadableError = decodeConcordiumStdError(rejectReasonCode);


### PR DESCRIPTION
## Purpose

Separate the error text from the disclaimer.

In the future, it would be good to move the `decodeRejectReason` function into our SDKs for re-usability.
https://github.com/Concordium/concordium-smart-contract-tools/blob/ef60b3cb6c396a013831c79c16bf961aa88292e1/front-end-tools/src/utils.ts#L165

## Changes

- Add a disclaimer text box to separate the disclaimer from the error text.
- Divide the large `read` function into smaller contained functions (such as `parseError` and `parseReturnValue` functions).

![Screenshot from 2024-06-21 09-21-20](https://github.com/Concordium/concordium-smart-contract-tools/assets/13039169/2d71160f-ff8d-431c-acb4-8fa55c61faf1)