### PR TITLE
Change default build output path

### DIFF
--- a/cargo-concordium/.vscode/settings.json
+++ b/cargo-concordium/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "rust-analyzer.rustfmt.overrideCommand": [
+    "rustfmt",
+    "+nightly-2023-04-01"
+  ]
+}

--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Added a `tag` option to `cargo concordium init`
 - When running integration tests the module output path is now exposed to the
   tests via the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.
+- Change the default build output path to `concordium-out/module.wasm.v1`.
+- Remove requirement for `--out` flag when using the `--verifiable` flag.
 
 ## 3.3.0
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -414,9 +414,9 @@ pub(crate) fn build_contract(
 
     let package_version_string = format!("{}-{}", package.name, package.version);
 
-    // If the output path is supplied make sure up-front before building anything
-    // that it points to a sensible location
-    let out_filename = match &out {
+    // Make sure up-front before building anything that the output path points to a
+    // sensible location
+    let mut out_filename = match &out {
         Some(out) => {
             // A path and a filename need to be provided when using the `--out` flag.
             if out.file_name().is_none() || out.is_dir() {
@@ -492,10 +492,9 @@ pub(crate) fn build_contract(
         let cwd = env::current_dir()
             .context("Unable to get working directory. Does it exist?")?
             .canonicalize()?;
-        let out_filename =
-            cwd.join(out.context("`--out` must be supplied when using verifiable builds.")?);
-        // The archive will be named after the `--out` parameter, by appending `.tar` to
-        // it.
+        out_filename = cwd.join(out_filename);
+        // The archive will be named after the module output path, by appending `.tar`
+        // to it.
         let tar_filename: PathBuf = {
             // Rust 1.70 has as_mut_os_string, but to support older versions we don't use it
             // here for now, and instead convert from and to OsString to append an

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -416,7 +416,7 @@ pub(crate) fn build_contract(
 
     // Make sure up-front before building anything that the output path points to a
     // sensible location
-    let mut out_filename = match &out {
+    let mut out_filename = match out {
         Some(out) => {
             // A path and a filename need to be provided when using the `--out` flag.
             if out.file_name().is_none() || out.is_dir() {
@@ -425,7 +425,7 @@ pub(crate) fn build_contract(
                      `./my/path/my_smart_contract.wasm.v1`)"
                 );
             }
-            out.clone()
+            out
         }
         None => {
             let extension = match version {

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -419,7 +419,6 @@ struct BuildOptions {
     #[structopt(
         name = "verifiable",
         long = "verifiable",
-        requires = "out",
         short = "r",
         help = "The image to use for a build of a contract that can be verified. If this is not \
                 supplied then the contract will be built in the context of the host, which is \


### PR DESCRIPTION
## Purpose

Closes #155.

## Changes

Changes the default output to `concordium-out/module.wasm.v1` (or `.v0`). Also removes the requirement for `--out`, when using `--verifiable`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.