### PR TITLE
Check for the `wasm32-unknown-unknown`  target

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Change the default build output path to `concordium-out/module.wasm.v1`.
 - Remove requirement for `--out` flag when using the `--verifiable` flag.
 - Embed the schema in the Wasm module by default. Therefore, the `--schema-embed` flag is now deprecated. This behavior can be disabled with the `--no-schema-embed` flag.
+- Fixed long error message when the `wasm32-unknown-unknown` target is not installed.
 
 ## 3.3.0
 

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -386,7 +386,7 @@ pub(crate) fn build_contract(
     out: Option<PathBuf>,
     cargo_args: &[String],
 ) -> anyhow::Result<BuildInfo> {
-    // Check that the wasm toolchain is installed
+    // Check that the wasm target is installed
     check_wasm_target()?;
 
     // Check immediately if reproducible build is requested that we can execute the
@@ -1257,7 +1257,7 @@ pub fn build_and_run_wasm_test(
     extra_args: &[String],
     seed: Option<u64>,
 ) -> anyhow::Result<bool> {
-    // Check that the wasm toolchain is installed
+    // Check that the wasm target is installed
     check_wasm_target()?;
 
     let (metadata, _) = get_crate_metadata(extra_args)?;

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -35,6 +35,7 @@ use std::{
     io::Write,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    str,
 };
 
 /// Encode all base64 strings using the standard alphabet and padding.
@@ -385,6 +386,9 @@ pub(crate) fn build_contract(
     out: Option<PathBuf>,
     cargo_args: &[String],
 ) -> anyhow::Result<BuildInfo> {
+    // Check that the wasm toolchain is installed
+    check_wasm_target()?;
+
     // Check immediately if reproducible build is requested that we can execute the
     // container runtime.
     if let Some(image) = &image {
@@ -1253,6 +1257,9 @@ pub fn build_and_run_wasm_test(
     extra_args: &[String],
     seed: Option<u64>,
 ) -> anyhow::Result<bool> {
+    // Check that the wasm toolchain is installed
+    check_wasm_target()?;
+
     let (metadata, _) = get_crate_metadata(extra_args)?;
 
     let target_dir = format!("{}/concordium", metadata.target_directory);
@@ -1373,4 +1380,35 @@ pub fn build_and_run_wasm_test(
         eprintln!("Unit test result: {}", Color::Red.bold().paint("FAILED"));
         Ok(false)
     }
+}
+
+/// Checks if the `wasm32-unknown-unknown` target is installed, and returns an
+/// error if not.
+fn check_wasm_target() -> anyhow::Result<()> {
+    // Try to check with rustup, which should be reliable, but it may not be
+    // installed. If not, check for a folder named
+    // `$sysroot/lib/rustlib/wasm32-unknown-unknown`.
+    let target_installed = if let Ok(rustup_output) = Command::new("rustup")
+        .args(["target", "list", "--installed"])
+        .output()
+    {
+        str::from_utf8(&rustup_output.stdout)?
+            .lines()
+            .any(|l| l == "wasm32-unknown-unknown")
+    } else {
+        let rustc_output = Command::new("rustc")
+            .args(["--print", "sysroot"])
+            .output()
+            .context("Unable to run `rustc`")?;
+        let mut target_path = PathBuf::from(str::from_utf8(&rustc_output.stdout)?.trim_end());
+        target_path.push("lib/rustlib/wasm32-unknown-unknown");
+        fs::metadata(target_path).is_ok_and(|m| m.is_dir())
+    };
+
+    anyhow::ensure!(
+        target_installed,
+        "Cannot find the `wasm32-unknown-unknown` target. Try installing it by running `rustup \
+         target add wasm32-unknown-unknown`."
+    );
+    Ok(())
 }


### PR DESCRIPTION
## Purpose

Closes #126.

## Changes

Tries to use `rustup` to check for the target. Falls back to looking for the target's directory: https://users.rust-lang.org/t/determining-installed-target-list-when-rustup-is-not-in-use/100594

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.