### PR TITLE
Update deps and prepare release of cargo-concordium and vscode ext

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -9,8 +9,9 @@
   Defaults to `releases/templates/latest`.
 - When running integration tests the module output path is now exposed to the
   tests via the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.
-- Introduce a default build output (`--out <PATH>`) path to `concordium-out/module.wasm.v1`.
-- Remove requirement for `--out` flag when using the `--verifiable` flag, now using the default output path.
+- Add the default build output (`--out <PATH>`) path `concordium-out/module.wasm.v1`.
+- Change `--out` flag being optional when using the `--verifiable` flag.
+- Change `--verifiable` flag to use the default output path if the `--out` flag is not set.
 - Embed the schema in the Wasm module by default and can be disabled using the `--no-schema-embed` flag. 
   The `--schema-embed` flag (short `-e`) is now deprecated.
 - Fixed long error message when the `wasm32-unknown-unknown` target is not installed.

--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -2,12 +2,17 @@
 
 ## Unreleased changes
 
-- Added a `tag` option to `cargo concordium init`
+## 4.0.0
+
+- Use smart contract v1 cost configuration when simulating locally (the reduce execution cost introduced as part of Concordium Protocol Version 7)
+- Added a `--tag <RELEASE-TAG>` option to `cargo concordium init` to allow specifying the release tag of the templates.
+  Defaults to `releases/templates/latest`.
 - When running integration tests the module output path is now exposed to the
   tests via the `CARGO_CONCORDIUM_TEST_MODULE_OUTPUT_PATH` environment variable.
-- Change the default build output path to `concordium-out/module.wasm.v1`.
-- Remove requirement for `--out` flag when using the `--verifiable` flag.
-- Embed the schema in the Wasm module by default. Therefore, the `--schema-embed` flag is now deprecated. This behavior can be disabled with the `--no-schema-embed` flag.
+- Introduce a default build output (`--out <PATH>`) path to `concordium-out/module.wasm.v1`.
+- Remove requirement for `--out` flag when using the `--verifiable` flag, now using the default output path.
+- Embed the schema in the Wasm module by default and can be disabled using the `--no-schema-embed` flag. 
+  The `--schema-embed` flag (short `-e`) is now deprecated.
 - Fixed long error message when the `wasm32-unknown-unknown` target is not installed.
 
 ## 3.3.0

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-concordium"
-version = "3.3.0"
+version = "4.0.0"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "9.1.0"
+version = "9.2.0"
 dependencies = [
  "base64",
  "bs58",
@@ -540,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "byteorder",
@@ -563,7 +563,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wasm"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "concordium-contracts-common",
@@ -574,7 +574,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "ark-bls12-381",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-concordium"
-version = "3.3.0"
+version = "4.0.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 license-file = "../LICENSE"
@@ -38,13 +38,13 @@ flate2 = "1.0"
 
 [dependencies.concordium-wasm]
 path = "../concordium-base/smart-contracts/wasm-transform"
-version = "4.0"
+version = "5.0"
 
 [dependencies.concordium-smart-contract-engine]
-version = "5.0"
+version = "6.0"
 path = "../concordium-base/smart-contracts/wasm-chain-integration/"
 features = ["display-state"]
 
 [dependencies.concordium_base]
-version = "5.0"
+version = "6.0"
 path = "../concordium-base/rust-src/concordium_base"

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -23,6 +23,7 @@ use concordium_wasm::{
     output::{write_custom_section, Output},
     parse::parse_skeleton,
     validate::ValidationConfig,
+    CostConfigurationV1,
 };
 use ptree::{print_tree_with, PrintConfig, TreeBuilder};
 use sha2::Digest;
@@ -1434,6 +1435,7 @@ fn handle_run_v0(run_cmd: RunCommand, module: &[u8]) -> anyhow::Result<()> {
                 &name,
                 parameter.as_parameter(),
                 false, // Whether number of logs should be limited. Limit removed in PV5.
+                CostConfigurationV1,
                 runner.energy,
             )
             .context("Initialization failed due to a runtime error.")?;
@@ -1533,6 +1535,7 @@ fn handle_run_v0(run_cmd: RunCommand, module: &[u8]) -> anyhow::Result<()> {
                 &init_state,
                 u16::MAX as usize, // Max parameter size in PV5.
                 false,             // Whether to limit number of logs. Limit removed in PV5.
+                CostConfigurationV1,
             )
             .context("Calling receive failed.")?;
             match res {
@@ -1875,6 +1878,7 @@ fn handle_run_v1(run_cmd: RunCommand, module: &[u8]) -> anyhow::Result<()> {
                 &name,
                 loader,
                 ValidationConfig::V1,
+                CostConfigurationV1,
                 false, /* Whether number of logs and size of return values should be limited.
                         * Limits removed in PV5. */
             )
@@ -1983,6 +1987,7 @@ fn handle_run_v1(run_cmd: RunCommand, module: &[u8]) -> anyhow::Result<()> {
 
             let artifact = concordium_wasm::utils::instantiate_with_metering(
                 ValidationConfig::V1,
+                CostConfigurationV1,
                 &v1::ConcordiumAllowedImports {
                     support_upgrade: true,
                     enable_debug:    true, /* we always allow the debug statements in the

--- a/vscode-smart-contracts/CHANGELOG.md
+++ b/vscode-smart-contracts/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 3.0.0
 
 - Contains `cargo-concordium` version 4.0.0
-- Contains `@concordium/ccd-js-gen` version 1.2.0
+- Contains `@concordium/ccd-js-gen` version 1.2.1
 
 ## 2.2.0
 

--- a/vscode-smart-contracts/CHANGELOG.md
+++ b/vscode-smart-contracts/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## 3.0.0
+
+- Contains `cargo-concordium` version 4.0.0
+- Contains `@concordium/ccd-js-gen` version 1.2.0
+
 ## 2.2.0
 
 - Contains `cargo-concordium` version 3.2.0

--- a/vscode-smart-contracts/README.md
+++ b/vscode-smart-contracts/README.md
@@ -65,6 +65,11 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+## 3.0.0
+
+- Contains `cargo-concordium` version 4.0.0
+- Contains `@concordium/ccd-js-gen` version 1.2.0
+
 ## 2.2.0
 
 - Contains `cargo-concordium` version 3.2.0

--- a/vscode-smart-contracts/README.md
+++ b/vscode-smart-contracts/README.md
@@ -68,7 +68,7 @@ This extension contributes the following settings:
 ## 3.0.0
 
 - Contains `cargo-concordium` version 4.0.0
-- Contains `@concordium/ccd-js-gen` version 1.2.0
+- Contains `@concordium/ccd-js-gen` version 1.2.1
 
 ## 2.2.0
 

--- a/vscode-smart-contracts/package-lock.json
+++ b/vscode-smart-contracts/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "concordium-smart-contracts",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "concordium-smart-contracts",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@concordium/ccd-js-gen": "^1.2.0",
+        "@concordium/ccd-js-gen": "^1.2.1",
         "glob": "^8.1.0"
       },
       "devDependencies": {
@@ -33,11 +33,11 @@
       }
     },
     "node_modules/@concordium/ccd-js-gen": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@concordium/ccd-js-gen/-/ccd-js-gen-1.2.0.tgz",
-      "integrity": "sha512-PCI0L/9Jc4FIcT6kBMdOAywZZxUHF3B5LKUO8/paOGifeeEC7sBX8gWCU2jbeHEmd42wT/g8w5uFqpDMbfOZ4w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@concordium/ccd-js-gen/-/ccd-js-gen-1.2.1.tgz",
+      "integrity": "sha512-yjGo9+ENab+stOxqxbNyFAm4xyYQU2SRGt+SUgZncKNMnZcOHAx9rq2ZcKVzV43hDYTFPAP7yQZxvKUzfd/e7w==",
       "dependencies": {
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^8.0.1",
         "buffer": "^6.0.3",
         "commander": "^11.0.0",
         "sanitize-filename": "^1.6.3",
@@ -47,7 +47,7 @@
         "ccd-js-gen": "bin/ccd-js-gen.js"
       },
       "peerDependencies": {
-        "@concordium/web-sdk": "7.x"
+        "@concordium/web-sdk": ">= 7"
       }
     },
     "node_modules/@concordium/ccd-js-gen/node_modules/buffer": {
@@ -82,19 +82,19 @@
       }
     },
     "node_modules/@concordium/rust-bindings": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@concordium/rust-bindings/-/rust-bindings-2.0.1.tgz",
-      "integrity": "sha512-4ZzHt31fUZ5DD8DSCITc7A+n9dY5+FyEfdYjucW0K8g+A9mdy1Rbcj1DrNI1MeKnoK8XdA1+X0pDrBAgVKwRgg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@concordium/rust-bindings/-/rust-bindings-3.2.1.tgz",
+      "integrity": "sha512-5mcuLWmPgjJNTqzd5LrXzBwh/pSrvLH0pEeWC4LF6ZO07a/Yj34H9NMFNz2QxLloioc9EcuJ+ec4HhOBeVu7rw==",
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@concordium/web-sdk": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@concordium/web-sdk/-/web-sdk-7.1.0.tgz",
-      "integrity": "sha512-79STpoz6qxOGt9OvRhalPaCkIgPFbbNDaFRL4/7Jq4dr62PqAo1u/rbo79kX3ySWPxu1CkjY2XSQ6yk539ljrw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@concordium/web-sdk/-/web-sdk-8.0.1.tgz",
+      "integrity": "sha512-Qfl2XD5aF11tOo9tpSi1jVtEfau+nwYB/6tK44/noEKw6RzA68v2viMxvwf0xST2Q/tdV5iXdA/zKbkQfDr6wg==",
       "dependencies": {
-        "@concordium/rust-bindings": "2.0.1",
+        "@concordium/rust-bindings": "^3.2.1",
         "@grpc/grpc-js": "^1.9.4",
         "@noble/ed25519": "^2.0.0",
         "@noble/hashes": "^1.3.2",
@@ -113,6 +113,9 @@
       },
       "engines": {
         "node": ">=16"
+      },
+      "peerDependencies": {
+        "@protobuf-ts/runtime-rpc": "^2.8.2"
       }
     },
     "node_modules/@concordium/web-sdk/node_modules/buffer": {
@@ -195,25 +198,25 @@
       }
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.11.tgz",
-      "integrity": "sha512-QDhMfbTROOXUhLHMroow8f3EHiCKUOh6UwxMP5S3EuXMnWMNSVIhatGZRwkpg9OUTYdZPsDUVH3cOAkWhGFUJw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.2.tgz",
+      "integrity": "sha512-DWp92gDD7/Qkj7r8kus6/HCINeo3yPZWZ3paKgDgsbKbSpoxKg1yvN8xe2Q8uE3zOsPe3bX8FQX2+XValq2yTw==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
       },
       "engines": {
-        "node": "^8.13.0 || >=10.10.0"
+        "node": ">=12.10.0"
       }
     },
     "node_modules/@grpc/proto-loader": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
-      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -294,23 +297,29 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@noble/ed25519": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.0.0.tgz",
-      "integrity": "sha512-/extjhkwFupyopDrt80OMWKdLgP429qLZj+z6sYJz90rF2Iz0gjZh2ArMKPImUl13Kx+0EXI2hN9T/KJV0/Zng==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://paulmillr.com/funding/"
-        }
-      ]
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.1.0.tgz",
+      "integrity": "sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -349,37 +358,37 @@
       }
     },
     "node_modules/@protobuf-ts/grpc-transport": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpc-transport/-/grpc-transport-2.9.1.tgz",
-      "integrity": "sha512-p3o69oQUqMX1dG0QcBsnK7/2h0ReEIfJRbZykMCumTn2uAc9znTfh74xB8aH8I5Q+sWphucG8mPytJ/QIW9WSA==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpc-transport/-/grpc-transport-2.9.4.tgz",
+      "integrity": "sha512-CgjTR3utmkMkkThpfgtOz9tNR9ZARbNoQYL7TCKqFU2sgAX0LgzAkwOx+sfgtUsZn9J08+yvn307nNJdYocLRA==",
       "dependencies": {
-        "@protobuf-ts/runtime": "^2.9.1",
-        "@protobuf-ts/runtime-rpc": "^2.9.1"
+        "@protobuf-ts/runtime": "^2.9.4",
+        "@protobuf-ts/runtime-rpc": "^2.9.4"
       },
       "peerDependencies": {
         "@grpc/grpc-js": "^1.6.0"
       }
     },
     "node_modules/@protobuf-ts/grpcweb-transport": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.9.1.tgz",
-      "integrity": "sha512-42bvBX312qhPlosMNTZE9XI+lt58ISM5vEJKv/wOx2Fu70J0TdlLa4Bjz8xcuRlv4Pq1CA+94DC1IgNxNRsQdg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.9.4.tgz",
+      "integrity": "sha512-6aQgwPTgX6FkqWqmNts3uk8T/C5coJoH7U87zgaZY/Wo2EVa9SId5bXTM8uo4WR+CN8j9W4c9ij1yG13Hc3xUw==",
       "dependencies": {
-        "@protobuf-ts/runtime": "^2.9.1",
-        "@protobuf-ts/runtime-rpc": "^2.9.1"
+        "@protobuf-ts/runtime": "^2.9.4",
+        "@protobuf-ts/runtime-rpc": "^2.9.4"
       }
     },
     "node_modules/@protobuf-ts/runtime": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.1.tgz",
-      "integrity": "sha512-ZTc8b+pQ6bwxZa3qg9/IO/M/brRkvr0tic9cSGgAsDByfPrtatT2300wTIRLDk8X9WTW1tT+FhyqmcrbMHTeww=="
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
+      "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg=="
     },
     "node_modules/@protobuf-ts/runtime-rpc": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.1.tgz",
-      "integrity": "sha512-pzO20J6s07LTWcj8hKAXh/dAacU5HIVir6SANKXXH8G0pn0VIIB4FFECq5Hbv25/8PQoOGZ7iApq/DMHaSjGhg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.4.tgz",
+      "integrity": "sha512-y9L9JgnZxXFqH5vD4d7j9duWvIJ7AShyBRoNKJGhu9Q27qIbchfzli66H9RvrQNIFk5ER7z1Twe059WZGqERcA==",
       "dependencies": {
-        "@protobuf-ts/runtime": "^2.9.1"
+        "@protobuf-ts/runtime": "^2.9.4"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -437,20 +446,20 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.8.tgz",
+      "integrity": "sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
       "dependencies": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.8"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1036,9 +1045,9 @@
       ]
     },
     "node_modules/big.js": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
-      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==",
       "engines": {
         "node": "*"
       },
@@ -1108,11 +1117,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1884,9 +1893,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2583,11 +2592,11 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -3106,9 +3115,9 @@
       "dev": true
     },
     "node_modules/protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -3928,11 +3937,11 @@
   },
   "dependencies": {
     "@concordium/ccd-js-gen": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@concordium/ccd-js-gen/-/ccd-js-gen-1.2.0.tgz",
-      "integrity": "sha512-PCI0L/9Jc4FIcT6kBMdOAywZZxUHF3B5LKUO8/paOGifeeEC7sBX8gWCU2jbeHEmd42wT/g8w5uFqpDMbfOZ4w==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@concordium/ccd-js-gen/-/ccd-js-gen-1.2.1.tgz",
+      "integrity": "sha512-yjGo9+ENab+stOxqxbNyFAm4xyYQU2SRGt+SUgZncKNMnZcOHAx9rq2ZcKVzV43hDYTFPAP7yQZxvKUzfd/e7w==",
       "requires": {
-        "@concordium/web-sdk": "^7.0.0",
+        "@concordium/web-sdk": "^8.0.1",
         "buffer": "^6.0.3",
         "commander": "^11.0.0",
         "sanitize-filename": "^1.6.3",
@@ -3956,16 +3965,16 @@
       }
     },
     "@concordium/rust-bindings": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@concordium/rust-bindings/-/rust-bindings-2.0.1.tgz",
-      "integrity": "sha512-4ZzHt31fUZ5DD8DSCITc7A+n9dY5+FyEfdYjucW0K8g+A9mdy1Rbcj1DrNI1MeKnoK8XdA1+X0pDrBAgVKwRgg=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@concordium/rust-bindings/-/rust-bindings-3.2.1.tgz",
+      "integrity": "sha512-5mcuLWmPgjJNTqzd5LrXzBwh/pSrvLH0pEeWC4LF6ZO07a/Yj34H9NMFNz2QxLloioc9EcuJ+ec4HhOBeVu7rw=="
     },
     "@concordium/web-sdk": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@concordium/web-sdk/-/web-sdk-7.1.0.tgz",
-      "integrity": "sha512-79STpoz6qxOGt9OvRhalPaCkIgPFbbNDaFRL4/7Jq4dr62PqAo1u/rbo79kX3ySWPxu1CkjY2XSQ6yk539ljrw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@concordium/web-sdk/-/web-sdk-8.0.1.tgz",
+      "integrity": "sha512-Qfl2XD5aF11tOo9tpSi1jVtEfau+nwYB/6tK44/noEKw6RzA68v2viMxvwf0xST2Q/tdV5iXdA/zKbkQfDr6wg==",
       "requires": {
-        "@concordium/rust-bindings": "2.0.1",
+        "@concordium/rust-bindings": "^3.2.1",
         "@grpc/grpc-js": "^1.9.4",
         "@noble/ed25519": "^2.0.0",
         "@noble/hashes": "^1.3.2",
@@ -4033,22 +4042,22 @@
       "dev": true
     },
     "@grpc/grpc-js": {
-      "version": "1.9.11",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.11.tgz",
-      "integrity": "sha512-QDhMfbTROOXUhLHMroow8f3EHiCKUOh6UwxMP5S3EuXMnWMNSVIhatGZRwkpg9OUTYdZPsDUVH3cOAkWhGFUJw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.11.2.tgz",
+      "integrity": "sha512-DWp92gDD7/Qkj7r8kus6/HCINeo3yPZWZ3paKgDgsbKbSpoxKg1yvN8xe2Q8uE3zOsPe3bX8FQX2+XValq2yTw==",
       "requires": {
-        "@grpc/proto-loader": "^0.7.8",
-        "@types/node": ">=12.12.47"
+        "@grpc/proto-loader": "^0.7.13",
+        "@js-sdsl/ordered-map": "^4.4.2"
       }
     },
     "@grpc/proto-loader": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
-      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
+      "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.2.4",
+        "protobufjs": "^7.2.5",
         "yargs": "^17.7.2"
       },
       "dependencies": {
@@ -4106,15 +4115,20 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="
+    },
     "@noble/ed25519": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.0.0.tgz",
-      "integrity": "sha512-/extjhkwFupyopDrt80OMWKdLgP429qLZj+z6sYJz90rF2Iz0gjZh2ArMKPImUl13Kx+0EXI2hN9T/KJV0/Zng=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-2.1.0.tgz",
+      "integrity": "sha512-KM4qTyXPinyCgMzeYJH/UudpdL+paJXtY3CHtHYZQtBkS8MZoPr4rOikZllIutJe0d06QDQKisyn02gxZ8TcQA=="
     },
     "@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4140,34 +4154,34 @@
       }
     },
     "@protobuf-ts/grpc-transport": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpc-transport/-/grpc-transport-2.9.1.tgz",
-      "integrity": "sha512-p3o69oQUqMX1dG0QcBsnK7/2h0ReEIfJRbZykMCumTn2uAc9znTfh74xB8aH8I5Q+sWphucG8mPytJ/QIW9WSA==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpc-transport/-/grpc-transport-2.9.4.tgz",
+      "integrity": "sha512-CgjTR3utmkMkkThpfgtOz9tNR9ZARbNoQYL7TCKqFU2sgAX0LgzAkwOx+sfgtUsZn9J08+yvn307nNJdYocLRA==",
       "requires": {
-        "@protobuf-ts/runtime": "^2.9.1",
-        "@protobuf-ts/runtime-rpc": "^2.9.1"
+        "@protobuf-ts/runtime": "^2.9.4",
+        "@protobuf-ts/runtime-rpc": "^2.9.4"
       }
     },
     "@protobuf-ts/grpcweb-transport": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.9.1.tgz",
-      "integrity": "sha512-42bvBX312qhPlosMNTZE9XI+lt58ISM5vEJKv/wOx2Fu70J0TdlLa4Bjz8xcuRlv4Pq1CA+94DC1IgNxNRsQdg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.9.4.tgz",
+      "integrity": "sha512-6aQgwPTgX6FkqWqmNts3uk8T/C5coJoH7U87zgaZY/Wo2EVa9SId5bXTM8uo4WR+CN8j9W4c9ij1yG13Hc3xUw==",
       "requires": {
-        "@protobuf-ts/runtime": "^2.9.1",
-        "@protobuf-ts/runtime-rpc": "^2.9.1"
+        "@protobuf-ts/runtime": "^2.9.4",
+        "@protobuf-ts/runtime-rpc": "^2.9.4"
       }
     },
     "@protobuf-ts/runtime": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.1.tgz",
-      "integrity": "sha512-ZTc8b+pQ6bwxZa3qg9/IO/M/brRkvr0tic9cSGgAsDByfPrtatT2300wTIRLDk8X9WTW1tT+FhyqmcrbMHTeww=="
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.4.tgz",
+      "integrity": "sha512-vHRFWtJJB/SiogWDF0ypoKfRIZ41Kq+G9cEFj6Qm1eQaAhJ1LDFvgZ7Ja4tb3iLOQhz0PaoPnnOijF1qmEqTxg=="
     },
     "@protobuf-ts/runtime-rpc": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.1.tgz",
-      "integrity": "sha512-pzO20J6s07LTWcj8hKAXh/dAacU5HIVir6SANKXXH8G0pn0VIIB4FFECq5Hbv25/8PQoOGZ7iApq/DMHaSjGhg==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.4.tgz",
+      "integrity": "sha512-y9L9JgnZxXFqH5vD4d7j9duWvIJ7AShyBRoNKJGhu9Q27qIbchfzli66H9RvrQNIFk5ER7z1Twe059WZGqERcA==",
       "requires": {
-        "@protobuf-ts/runtime": "^2.9.1"
+        "@protobuf-ts/runtime": "^2.9.4"
       }
     },
     "@protobufjs/aspromise": {
@@ -4225,17 +4239,17 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "@scure/base": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.3.tgz",
-      "integrity": "sha512-/+SgoRjLq7Xlf0CWuLHq2LUZeL/w65kfzAPG5NH9pcmBhs+nunQTn4gvdwgMTIXnt9b2C/1SeL2XiysZEyIC9Q=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.8.tgz",
+      "integrity": "sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg=="
     },
     "@scure/bip39": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.1.tgz",
-      "integrity": "sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
       "requires": {
-        "@noble/hashes": "~1.3.0",
-        "@scure/base": "~1.1.0"
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.8"
       }
     },
     "@tootallnate/once": {
@@ -4642,9 +4656,9 @@
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "big.js": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
-      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.2.tgz",
+      "integrity": "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ=="
     },
     "bignumber.js": {
       "version": "9.1.2",
@@ -4700,11 +4714,11 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "browser-stdout": {
@@ -5277,9 +5291,9 @@
       }
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -5806,11 +5820,11 @@
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },
@@ -6197,9 +6211,9 @@
       "dev": true
     },
     "protobufjs": {
-      "version": "7.2.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
-      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
+      "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/vscode-smart-contracts/package.json
+++ b/vscode-smart-contracts/package.json
@@ -176,7 +176,7 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@concordium/ccd-js-gen": "^1.2.0",
+    "@concordium/ccd-js-gen": "^1.2.1",
     "glob": "^8.1.0"
   }
 }

--- a/vscode-smart-contracts/package.json
+++ b/vscode-smart-contracts/package.json
@@ -4,7 +4,7 @@
   "displayName": "Concordium Smart Contracts",
   "icon": "icon.png",
   "description": "Develop and build smart contracts on Concordium",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/Concordium/concordium-smart-contract-tools.git",

--- a/vscode-smart-contracts/src/commands.ts
+++ b/vscode-smart-contracts/src/commands.ts
@@ -127,16 +127,15 @@ async function buildTask(
 
   const schemaArgs =
     schemaSettings === "skip"
-      ? []
+      ? ["--no-schema-embed"]
       : schemaSettings === "embed-and-outDir"
       ? [
-          "--schema-embed",
           "--schema-json-out",
           outDir,
           "--schema-base64-out",
           path.join(outDir, "module-schema.bs64"),
         ]
-      : ["--schema-json-out", outDir];
+      : ["--no-schema-embed", "--schema-json-out", outDir];
   const additionalArgs = config.getAdditionalBuildArgs();
   const moduleOut = path.join(outDir, "module.wasm.v1");
   const args = ["--out", moduleOut].concat(schemaArgs, additionalArgs);

--- a/vscode-smart-contracts/src/extension.ts
+++ b/vscode-smart-contracts/src/extension.ts
@@ -85,7 +85,6 @@ const taskProvider: vscode.TaskProvider = {
               defaultOutDir,
               "--schema-base64-out",
               path.join(defaultOutDir, "module-schema.bs64"),
-              "--schema-embed",
             ];
             const defaultJsGenArgs = [
               "--module",


### PR DESCRIPTION
## Purpose

- Update dependencies to prepare for Concordium Protocol Version 7.
- Prepare releases for `cargo-concordium` version `4.0.0` and the vscode extension version `3.0.0`.
- Adjust VS Code extension, such that the new defaults of `cargo-concordium` does not break the already exposed commands.