### PR TITLE
Build cargo-concordium for Mac ARM64 in vscode release

### DIFF
--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -36,15 +36,26 @@ jobs:
         run: |
           rustup target add x86_64-unknown-linux-musl
           cargo build --release --manifest-path cargo-concordium/Cargo.toml --target x86_64-unknown-linux-musl
-      - name: Build on other platforms
-        if: matrix.platfrom != 'ubuntu-latest'
+      - name: Build on windows
+        if: matrix.platfrom == 'windows-latest'
         run: cargo build --release --manifest-path cargo-concordium/Cargo.toml
+      - name: Build on macos
+        if: matrix.platfrom == 'macos-latest'
+        run: |
+          # Build x86_64
+          cargo build --release --manifest-path cargo-concordium/Cargo.toml
+          # Build ARM64 and rename it.
+          rustup target add aarch64-apple-darwin
+          cargo build --release --manifest-path cargo-concordium/Cargo.toml --target aarch64-apple-darwin
+          mv cargo-concordium/target/release/aarch64-apple-darwin/cargo-concordium cargo-concordium/target/release/aarch64-apple-darwin/cargo-concordium-aarch64
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: binary-${{ matrix.platform }}
           path: |
             cargo-concordium/target/release/cargo-concordium
+            cargo-concordium/target/release/aarch64-apple-darwin/cargo-concordium-aarch64
             cargo-concordium/target/release/x86_64-unknown-linux-musl/cargo-concordium
             cargo-concordium/target/release/cargo-concordium.exe
 
@@ -68,11 +79,15 @@ jobs:
           # Install dependencies
           npm ci
 
-          # Mac first
+          # Mac x86_64 first
           mv ../binary-macos-latest/cargo-concordium executables/cargo-concordium
           chmod +x executables/cargo-concordium
-
           npx vsce package --target darwin-x64 --out ./out/extension-darwin-x64.vsix
+
+          # Then Mac ARM64
+          rm -rf executables/*
+          mv ../binary-macos-latest/cargo-concordium-aarch64 executables/cargo-concordium
+          chmod +x executables/cargo-concordium
           npx vsce package --target darwin-arm64 --out ./out/extension-darwin-arm64.vsix
 
           # Then Windows

--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -47,7 +47,7 @@ jobs:
           # Build ARM64 and rename it.
           rustup target add aarch64-apple-darwin
           cargo build --release --manifest-path cargo-concordium/Cargo.toml --target aarch64-apple-darwin
-          mv cargo-concordium/target/release/aarch64-apple-darwin/cargo-concordium cargo-concordium/target/release/aarch64-apple-darwin/cargo-concordium-aarch64
+          mv cargo-concordium/target/release/aarch64-apple-darwin/cargo-concordium cargo-concordium/target/release/cargo-concordium-aarch64
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -55,7 +55,7 @@ jobs:
           name: binary-${{ matrix.platform }}
           path: |
             cargo-concordium/target/release/cargo-concordium
-            cargo-concordium/target/release/aarch64-apple-darwin/cargo-concordium-aarch64
+            cargo-concordium/target/release/cargo-concordium-aarch64
             cargo-concordium/target/release/x86_64-unknown-linux-musl/cargo-concordium
             cargo-concordium/target/release/cargo-concordium.exe
 

--- a/vscode-smart-contracts/CHANGELOG.md
+++ b/vscode-smart-contracts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.0.1
+
+- On MacOS ARM64, ship with `cargo-concordium` build for ARM64 instead of x86_64.
+
 ## 3.0.0
 
 - Contains `cargo-concordium` version 4.0.0

--- a/vscode-smart-contracts/README.md
+++ b/vscode-smart-contracts/README.md
@@ -65,6 +65,10 @@ This extension contributes the following settings:
 
 ## Release Notes
 
+## 3.0.1
+
+- On MacOS ARM64, ship with `cargo-concordium` build for ARM64 instead of x86_64.
+
 ## 3.0.0
 
 - Contains `cargo-concordium` version 4.0.0

--- a/vscode-smart-contracts/package.json
+++ b/vscode-smart-contracts/package.json
@@ -4,7 +4,7 @@
   "displayName": "Concordium Smart Contracts",
   "icon": "icon.png",
   "description": "Develop and build smart contracts on Concordium",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/Concordium/concordium-smart-contract-tools.git",


### PR DESCRIPTION
## Purpose

Our vscode extension distribution for MacOS ARM is shipping with `cargo-concordium` build for `x86_64` which means the user depends on rosetta.
This PR will add cross-compiling for Macos and prepare a new release with this binary.