### PR TITLE
Add executable permission to cargo-concordium in vscode release on linux

### DIFF
--- a/.github/workflows/release-vscode-extension.yml
+++ b/.github/workflows/release-vscode-extension.yml
@@ -99,6 +99,7 @@ jobs:
           echo "Finally linux"
           rm -rf executables/*
           mv ../binary-ubuntu-latest/x86_64-unknown-linux-musl/release/cargo-concordium executables/cargo-concordium
+          chmod +x executables/cargo-concordium
           npx vsce package --target linux-x64 --out ./out/extension-linux-x64.vsix
 
       - name: Upload extension artifacts

--- a/vscode-smart-contracts/package-lock.json
+++ b/vscode-smart-contracts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "concordium-smart-contracts",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "concordium-smart-contracts",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@concordium/ccd-js-gen": "^1.2.1",


### PR DESCRIPTION
## Purpose

Fix linux distribution of vscode extension

## Changes

Add executable permission to cargo-concordium before packaging the vscode extension
