### PR TITLE
Reduce the level of optimization used by default in cargo concordium

### DIFF
--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## 4.1.1
 
 - Tune down the level of optimization during the build step (introduced in 4.1.0) as it resulted in changing behavior for some smart contracts.
+- Run `wasm-opt` step when building WASM unit tests.
 
 ## 4.1.0
 

--- a/cargo-concordium/CHANGELOG.md
+++ b/cargo-concordium/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## 4.1.1
+
+- Tune down the level of optimization during the build step (introduced in 4.1.0) as it resulted in changing behavior for some smart contracts.
+
 ## 4.1.0
 
 - Add support for `--skip-wasm-opt` flag opting out of the `wasm-opt` step.
@@ -17,7 +21,7 @@
 - Add the default build output (`--out <PATH>`) path `concordium-out/module.wasm.v1`.
 - Change `--out` flag being optional when using the `--verifiable` flag.
 - Change `--verifiable` flag to use the default output path if the `--out` flag is not set.
-- Embed the schema in the Wasm module by default and can be disabled using the `--no-schema-embed` flag. 
+- Embed the schema in the Wasm module by default and can be disabled using the `--no-schema-embed` flag.
   The `--schema-embed` flag (short `-e`) is now deprecated.
 - Fixed long error message when the `wasm32-unknown-unknown` target is not installed.
 

--- a/cargo-concordium/Cargo.lock
+++ b/cargo-concordium/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-concordium"
-version = "4.1.0"
+version = "4.1.1"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/cargo-concordium/Cargo.toml
+++ b/cargo-concordium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-concordium"
-version = "4.1.0"
+version = "4.1.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 license-file = "../LICENSE"

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -572,7 +572,7 @@ pub(crate) fn build_contract(
         }
 
         if !skip_wasm_opt {
-            wasm_opt::OptimizationOptions::new_optimize_for_size()
+            wasm_opt::OptimizationOptions::new_opt_level_0()
                 .run(&output_wasm_file, &output_wasm_file)
                 .context("Failed running wasm_opt")?;
         }
@@ -797,7 +797,7 @@ pub fn build_contract_schema<A>(
     );
 
     if !skip_wasm_opt {
-        wasm_opt::OptimizationOptions::new_optimize_for_size()
+        wasm_opt::OptimizationOptions::new_opt_level_0()
             .run(&filename, &filename)
             .context("Failed running wasm_opt")?;
     }

--- a/cargo-concordium/src/build.rs
+++ b/cargo-concordium/src/build.rs
@@ -1278,6 +1278,7 @@ pub fn build_and_run_wasm_test(
     enable_debug: bool,
     extra_args: &[String],
     seed: Option<u64>,
+    skip_wasm_opt: bool,
 ) -> anyhow::Result<bool> {
     // Check that the wasm target is installed
     check_wasm_target()?;
@@ -1339,6 +1340,11 @@ pub fn build_and_run_wasm_test(
         target_dir,
         to_snake_case(package.name.as_str())
     );
+    if !skip_wasm_opt {
+        wasm_opt::OptimizationOptions::new_opt_level_0()
+            .run(&filename, &filename)
+            .context("Failed running wasm_opt")?;
+    }
 
     let wasm = std::fs::read(filename).context("Failed reading contract test output artifact.")?;
 

--- a/cargo-concordium/src/main.rs
+++ b/cargo-concordium/src/main.rs
@@ -687,9 +687,13 @@ pub fn main() -> anyhow::Result<()> {
             only_unit_tests,
             test_targets,
         } => {
-            let unit_test_success =
-                build_and_run_wasm_test(build_options.allow_debug, &build_options.cargo_args, seed)
-                    .context("Could not build and run unit tests.")?;
+            let unit_test_success = build_and_run_wasm_test(
+                build_options.allow_debug,
+                &build_options.cargo_args,
+                seed,
+                build_options.skip_wasm_opt,
+            )
+            .context("Could not build and run unit tests.")?;
             if !only_unit_tests {
                 build_and_run_integration_tests(build_options, test_targets)
                     .context("Could not build and run integration tests.")?;


### PR DESCRIPTION
## Purpose

Fixes #198 

Latest release of cargo-concordium (4.1.0) introduced an optimization step as part of the build process (using wasm-opt), but this introduced a change in behavior for some smart contracts.
This PR reduces the optimization level again, without removing the `wasm-opt` step.

Also prepares for releasing a patch