### PR TITLE
Add nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,4 @@ pkg
 **/concordium-out
 
 # Nix
-**/*.nix
-**/flake.lock
 **/result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1763966396,
+        "narHash": "sha256-6eeL1YPcY1MV3DDStIDIdy/zZCDKgHdkCmsrLJFiZf0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5ae3b07d8d6527c42f17c876e404993199144b6a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1764038373,
+        "narHash": "sha256-M6w2wNBRelcavoDAyFL2iO4NeWknD40ASkH1S3C0YGM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "ab3536fe850211a96673c6ffb2cb88aab8071cc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,88 @@
+## WARNING
+#
+# Nix is not officially supported by Concordium, as such this flake is
+# not guaranteed to work or be maintained. Use at your own risk and do not
+# create Github issues regarding Nix!
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # Provides helpers for Rust toolchains
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = { self, nixpkgs, rust-overlay }:
+    let
+      rustVersion = "1.85.0";
+
+      # Systems supported
+      allSystems = [
+        "x86_64-linux" # 64-bit Intel/AMD Linux
+        "aarch64-linux" # 64-bit ARM Linux
+        "x86_64-darwin" # 64-bit Intel macOS
+        "aarch64-darwin" # 64-bit ARM macOS
+      ];
+
+      # Helper to provide system-specific attributes
+      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            # Provides Nixpkgs with a rust-bin attribute for building Rust toolchains
+            rust-overlay.overlays.default
+            # Uses the rust-bin attribute to select a Rust toolchain
+            self.overlays.default
+          ];
+        };
+      });
+    in
+    {
+      overlays.default = final: prev: {
+        # The Rust toolchain used for the package build
+        rustToolchain = final.rust-bin.stable."${rustVersion}".default.override {
+          targets = [ "wasm32-unknown-unknown" "wasm32v1-none" "x86_64-unknown-linux-gnu" ];
+          extensions = [ "rust-analyzer" "rust-src" ];
+        };
+        # Nightly Toolchain instead:
+        # rustToolchain = final.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default.override {
+        #   targets = [ "wasm32-unknown-unknown" "wasm32v1-none" "x86_64-unknown-linux-gnu" ];
+        #   extensions = [ "rust-analyzer" "rust-src" ];
+        # });
+      };
+
+      devShells = forAllSystems ({ pkgs } : {
+        default = pkgs.mkShell {
+          # Default to podman for the container runtime
+          CARGO_CONCORDIUM_CONTAINER_RUNTIME="podman";
+          # Create a cargo-concordium alias that points to the current WIP cargo-concordium
+          shellHook = ''export CARGO_CONCORDIUM_MANIFEST_PATH="$(git rev-parse --show-toplevel)/cargo-concordium/Cargo.toml"'';
+          buildInputs = with pkgs; [
+            rustToolchain
+            (writeShellApplication {
+              name = "cargo-concordium";
+              text = ''
+                cargo run --manifest-path "$CARGO_CONCORDIUM_MANIFEST_PATH" -- concordium "$@"
+              '';
+            })
+          ];
+        };
+      });
+
+      packages = forAllSystems ({ pkgs }: {
+        default =
+          let
+            manifest = (pkgs.lib.importTOML ./cargo-concordium/Cargo.toml).package;
+            rustPlatform = pkgs.makeRustPlatform {
+              cargo = pkgs.rustToolchain;
+              rustc = pkgs.rustToolchain;
+            };
+          in
+          rustPlatform.buildRustPackage {
+            name = manifest.name;
+            version = manifest.version;
+            src = pkgs.lib.cleanSource ./cargo-concordium;
+            cargoLock.lockFile = ./cargo-concordium/Cargo.lock;
+          };
+      });
+    };
+}


### PR DESCRIPTION
## Purpose

Adds a nix flake. 

Nix flakes are ways in which to declare reproducible development environments. This one declares rust stable 1.85 as a dependency (along with the wasm-targets and rust-analyzer) and creates a handy alias for running a WIP `cargo-concordium`. Fun fact, it would allow someone to run the latest `main` version of `cargo-concordium` by typing `nix run github:Concordium/concordium-smart-contract-tools` without needing to manually install any other dependencies except nix.

This is useful for me since I prefer flakes for my development environments and having them checked in simplifies my workflow somewhat. It *may* also be useful to others which is an added benefit. This is not an effort to support nix officially, as described very explicitly by the disclaimer at the top of the `flake.nix` file.

Files:

- `.envrc`: Tells direnv to use flakes. This means that if direnv+nix is installed all required tools will be installed and enabled automatically upon entering the directory.
- `flake.nix`: The nix flake which defines what tools should be installed to develop on this project.
- `flake.lock`: A standard lock file, ensuring reproducibility.

I'll leave this as a draft until I get back from exams.